### PR TITLE
CATO-3000 changing BoxValues to an object that takes any BoxRetriever

### DIFF
--- a/src/main/scala/uk/gov/hmrc/ct/accounts/retriever/AccountsBoxRetriever.scala
+++ b/src/main/scala/uk/gov/hmrc/ct/accounts/retriever/AccountsBoxRetriever.scala
@@ -19,8 +19,6 @@ package uk.gov.hmrc.ct.accounts.retriever
 import uk.gov.hmrc.ct.accounts._
 import uk.gov.hmrc.ct.box.retriever.{FilingAttributesBoxValueRetriever, BoxRetriever, BoxValues}
 
-object AccountsBoxRetriever extends BoxValues[AccountsBoxRetriever]
-
 trait AccountsBoxRetriever extends BoxRetriever {
 
   self: FilingAttributesBoxValueRetriever =>

--- a/src/main/scala/uk/gov/hmrc/ct/box/retriever/BoxValues.scala
+++ b/src/main/scala/uk/gov/hmrc/ct/box/retriever/BoxValues.scala
@@ -20,9 +20,9 @@ import java.lang.reflect.{Method, Modifier}
 
 import uk.gov.hmrc.ct.box.CtValue
 
-trait BoxValues[T] {
+object BoxValues {
 
-  def generateValues(retriever: T): Map[String, CtValue[_]] = {
+  def generateValues[T <: BoxRetriever](retriever: T): Map[String, CtValue[_]] = {
     retrieveBoxIdFunctions(retriever.getClass).map { method =>
       val boxName = method.getReturnType.getSimpleName
       method.invoke(retriever) match {
@@ -31,20 +31,17 @@ trait BoxValues[T] {
     }.toMap
   }
 
-  def retrieveBoxIdFunctions(retrieverClass: Class[_]): Seq[Method] = {
-    retrieverClass.getMethods
-      .filter(retrieveBoxMethod)
-  }
+  def retrieveBoxIdFunctions(retrieverClass: Class[_]): Seq[Method] = retrieverClass.getMethods.filter(retrieveBoxMethod)
 
   protected def retrieveBoxMethod: (Method) => Boolean = x => isPublic(x) && isAnyRetrieveBoxMethod(x) && hasNoParameters(x) && returnsCatoValue(x)
 
-  protected def retrieveBoxMethod(boxId: String): (Method) => Boolean = x => isPublic(x) && isRetrieveBoxMethod(x, boxId) && hasNoParameters(x) && returnsCatoValue(x)
+//  protected def retrieveBoxMethod(boxId: String): (Method) => Boolean = x => isPublic(x) && isRetrieveBoxMethod(x, boxId) && hasNoParameters(x) && returnsCatoValue(x)
 
   protected def hasNoParameters(method: Method): Boolean = method.getParameterTypes.isEmpty
 
   protected def isAnyRetrieveBoxMethod(method: Method): Boolean = method.getName.startsWith("retrieve")
 
-  protected def isRetrieveBoxMethod(method: Method, boxId: String): Boolean = method.getName.matches("retrieve" + boxId)
+//  protected def isRetrieveBoxMethod(method: Method, boxId: String): Boolean = method.getName.matches("retrieve" + boxId)
 
   protected def isPublic(method: Method): Boolean = Modifier.isPublic(method.getModifiers)
 

--- a/src/main/scala/uk/gov/hmrc/ct/box/retriever/BoxValues.scala
+++ b/src/main/scala/uk/gov/hmrc/ct/box/retriever/BoxValues.scala
@@ -35,13 +35,9 @@ object BoxValues {
 
   protected def retrieveBoxMethod: (Method) => Boolean = x => isPublic(x) && isAnyRetrieveBoxMethod(x) && hasNoParameters(x) && returnsCatoValue(x)
 
-//  protected def retrieveBoxMethod(boxId: String): (Method) => Boolean = x => isPublic(x) && isRetrieveBoxMethod(x, boxId) && hasNoParameters(x) && returnsCatoValue(x)
-
   protected def hasNoParameters(method: Method): Boolean = method.getParameterTypes.isEmpty
 
   protected def isAnyRetrieveBoxMethod(method: Method): Boolean = method.getName.startsWith("retrieve")
-
-//  protected def isRetrieveBoxMethod(method: Method, boxId: String): Boolean = method.getName.matches("retrieve" + boxId)
 
   protected def isPublic(method: Method): Boolean = Modifier.isPublic(method.getModifiers)
 

--- a/src/main/scala/uk/gov/hmrc/ct/box/retriever/FilingAttributesBoxValueRetriever.scala
+++ b/src/main/scala/uk/gov/hmrc/ct/box/retriever/FilingAttributesBoxValueRetriever.scala
@@ -18,8 +18,6 @@ package uk.gov.hmrc.ct.box.retriever
 
 import uk.gov.hmrc.ct._
 
-object FilingAttributesBoxValueRetriever extends BoxValues[FilingAttributesBoxValueRetriever]
-
 trait FilingAttributesBoxValueRetriever extends BoxRetriever {
 
   def retrieveProductName(): ProductName

--- a/src/main/scala/uk/gov/hmrc/ct/computations/retriever/ComputationsBoxRetriever.scala
+++ b/src/main/scala/uk/gov/hmrc/ct/computations/retriever/ComputationsBoxRetriever.scala
@@ -21,8 +21,6 @@ import uk.gov.hmrc.ct.accounts.retriever.AccountsBoxRetriever
 import uk.gov.hmrc.ct.box.retriever.{BoxRetriever, BoxValues}
 import uk.gov.hmrc.ct.computations._
 
-object ComputationsBoxRetriever extends BoxValues[ComputationsBoxRetriever]
-
 trait ComputationsBoxRetriever extends BoxRetriever {
 
   def retrieveAP1(): AP1

--- a/src/main/scala/uk/gov/hmrc/ct/ct600/retriever/DeclarationBoxRetriever.scala
+++ b/src/main/scala/uk/gov/hmrc/ct/ct600/retriever/DeclarationBoxRetriever.scala
@@ -19,8 +19,6 @@ package uk.gov.hmrc.ct.ct600.retriever
 import uk.gov.hmrc.ct.box.retriever.{BoxValues, BoxRetriever}
 import uk.gov.hmrc.ct.{CATO12, CATO11, CATO10}
 
-object DeclarationBoxRetriever extends BoxValues[DeclarationBoxRetriever]
-
 trait DeclarationBoxRetriever extends BoxRetriever {
 
   def retrieveCATO10(): CATO10

--- a/src/main/scala/uk/gov/hmrc/ct/ct600/v2/retriever/CT600BoxRetriever.scala
+++ b/src/main/scala/uk/gov/hmrc/ct/ct600/v2/retriever/CT600BoxRetriever.scala
@@ -23,8 +23,6 @@ import uk.gov.hmrc.ct.computations.retriever.ComputationsBoxRetriever
 import uk.gov.hmrc.ct.ct600.v2._
 import uk.gov.hmrc.ct.ct600a.v2.retriever.CT600ABoxRetriever
 
-object CT600BoxRetriever extends BoxValues[CT600BoxRetriever]
-
 trait CT600BoxRetriever extends ComputationsBoxRetriever {
 
   self: AccountsBoxRetriever =>

--- a/src/main/scala/uk/gov/hmrc/ct/ct600/v2/retriever/RepaymentsBoxRetriever.scala
+++ b/src/main/scala/uk/gov/hmrc/ct/ct600/v2/retriever/RepaymentsBoxRetriever.scala
@@ -16,10 +16,8 @@
 
 package uk.gov.hmrc.ct.ct600.v2.retriever
 
-import uk.gov.hmrc.ct.box.retriever.{BoxValues, BoxRetriever}
+import uk.gov.hmrc.ct.box.retriever.BoxRetriever
 import uk.gov.hmrc.ct.ct600.v2._
-
-object RepaymentsBoxRetriever extends BoxValues[RepaymentsBoxRetriever]
 
 trait RepaymentsBoxRetriever extends BoxRetriever {
 

--- a/src/main/scala/uk/gov/hmrc/ct/ct600/v3/retriever/CT600BoxRetriever.scala
+++ b/src/main/scala/uk/gov/hmrc/ct/ct600/v3/retriever/CT600BoxRetriever.scala
@@ -26,8 +26,6 @@ import uk.gov.hmrc.ct.ct600j.v3.{B65, B140}
 import uk.gov.hmrc.ct.ct600j.v3.retriever.CT600JBoxRetriever
 import uk.gov.hmrc.ct.ct600.v3.B45
 
-object CT600BoxRetriever extends BoxValues[CT600BoxRetriever]
-
 trait CT600BoxRetriever extends ComputationsBoxRetriever with CT600DeclarationBoxRetriever {
 
   self: AccountsBoxRetriever with FilingAttributesBoxValueRetriever =>

--- a/src/main/scala/uk/gov/hmrc/ct/ct600/v3/retriever/CT600DeclarationBoxRetriever.scala
+++ b/src/main/scala/uk/gov/hmrc/ct/ct600/v3/retriever/CT600DeclarationBoxRetriever.scala
@@ -19,8 +19,6 @@ package uk.gov.hmrc.ct.ct600.v3.retriever
 import uk.gov.hmrc.ct.box.retriever.{BoxValues, BoxRetriever}
 import uk.gov.hmrc.ct.ct600.v3.{B980, N092, B985, B975}
 
-object CT600DeclarationBoxRetriever extends BoxValues[CT600DeclarationBoxRetriever]
-
 trait CT600DeclarationBoxRetriever extends BoxRetriever {
 
   def retrieveB975(): B975

--- a/src/main/scala/uk/gov/hmrc/ct/ct600a/v2/retriever/CT600ABoxRetriever.scala
+++ b/src/main/scala/uk/gov/hmrc/ct/ct600a/v2/retriever/CT600ABoxRetriever.scala
@@ -22,8 +22,6 @@ import uk.gov.hmrc.ct.computations.retriever.ComputationsBoxRetriever
 import uk.gov.hmrc.ct.ct600.v2.B79
 import uk.gov.hmrc.ct.ct600a.v2._
 
-object CT600ABoxRetriever extends BoxValues[CT600ABoxRetriever]
-
 trait CT600ABoxRetriever extends ComputationsBoxRetriever {
 
   self: AccountsBoxRetriever =>

--- a/src/main/scala/uk/gov/hmrc/ct/ct600a/v3/retriever/CT600ABoxRetriever.scala
+++ b/src/main/scala/uk/gov/hmrc/ct/ct600a/v3/retriever/CT600ABoxRetriever.scala
@@ -23,8 +23,6 @@ import uk.gov.hmrc.ct.ct600.v3.B95
 import uk.gov.hmrc.ct.ct600.v3.retriever.CT600BoxRetriever
 import uk.gov.hmrc.ct.ct600a.v3._
 
-object CT600ABoxRetriever extends BoxValues[CT600ABoxRetriever]
-
 trait CT600ABoxRetriever extends ComputationsBoxRetriever {
 
   self: CT600BoxRetriever with AccountsBoxRetriever =>

--- a/src/main/scala/uk/gov/hmrc/ct/ct600e/v2/retriever/CT600EBoxRetriever.scala
+++ b/src/main/scala/uk/gov/hmrc/ct/ct600e/v2/retriever/CT600EBoxRetriever.scala
@@ -19,8 +19,6 @@ package uk.gov.hmrc.ct.ct600e.v2.retriever
 import uk.gov.hmrc.ct.box.retriever.{FilingAttributesBoxValueRetriever, BoxValues, BoxRetriever}
 import uk.gov.hmrc.ct.ct600e.v2._
 
-object CT600EBoxRetriever extends BoxValues[CT600EBoxRetriever]
-
 trait CT600EBoxRetriever extends BoxRetriever {
 
   def retrieveE1(): E1

--- a/src/main/scala/uk/gov/hmrc/ct/ct600e/v3/retriever/CT600EBoxRetriever.scala
+++ b/src/main/scala/uk/gov/hmrc/ct/ct600e/v3/retriever/CT600EBoxRetriever.scala
@@ -19,8 +19,6 @@ package uk.gov.hmrc.ct.ct600e.v3.retriever
 import uk.gov.hmrc.ct.box.retriever.{FilingAttributesBoxValueRetriever, BoxValues, BoxRetriever}
 import uk.gov.hmrc.ct.ct600e.v3._
 
-object CT600EBoxRetriever extends BoxValues[CT600EBoxRetriever]
-
 trait CT600EBoxRetriever extends BoxRetriever {
 
   self: FilingAttributesBoxValueRetriever =>

--- a/src/main/scala/uk/gov/hmrc/ct/ct600j/v2/retriever/CT600JBoxRetriever.scala
+++ b/src/main/scala/uk/gov/hmrc/ct/ct600j/v2/retriever/CT600JBoxRetriever.scala
@@ -16,10 +16,7 @@
 
 package uk.gov.hmrc.ct.ct600j.v2.retriever
 
-import uk.gov.hmrc.ct.box.retriever.BoxValues
 import uk.gov.hmrc.ct.ct600j.v2.TAQ01
-
-object CT600JBoxRetriever extends BoxValues[CT600JBoxRetriever]
 
 trait CT600JBoxRetriever {
 

--- a/src/main/scala/uk/gov/hmrc/ct/ct600j/v3/retriever/CT600JBoxRetriever.scala
+++ b/src/main/scala/uk/gov/hmrc/ct/ct600j/v3/retriever/CT600JBoxRetriever.scala
@@ -16,12 +16,10 @@
 
 package uk.gov.hmrc.ct.ct600j.v3.retriever
 
-import uk.gov.hmrc.ct.box.retriever.{FilingAttributesBoxValueRetriever, BoxRetriever, BoxValues}
+import uk.gov.hmrc.ct.box.retriever.{BoxRetriever, FilingAttributesBoxValueRetriever}
 import uk.gov.hmrc.ct.computations.retriever.ComputationsBoxRetriever
 import uk.gov.hmrc.ct.ct600.v3.retriever.CT600BoxRetriever
 import uk.gov.hmrc.ct.ct600j.v3._
-
-object CT600JBoxRetriever extends BoxValues[CT600JBoxRetriever]
 
 trait CT600JBoxRetriever extends BoxRetriever {
 

--- a/src/test/scala/uk/gov/hmrc/ct/box/retriever/FilingAttributesBoxValueRetrieverSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/ct/box/retriever/FilingAttributesBoxValueRetrieverSpec.scala
@@ -26,13 +26,13 @@ class FilingAttributesBoxValueRetrieverSpec extends WordSpec with Matchers {
 
   "FilingAttributesBoxValueRetriever" should {
     "have 10 functions" in {
-      FilingAttributesBoxValueRetriever.retrieveBoxIdFunctions(classOf[FilingAttributesBoxValueRetriever]).size shouldBe 10
+      BoxValues.retrieveBoxIdFunctions(classOf[FilingAttributesBoxValueRetriever]).size shouldBe 10
     }
 
     "get ct values" in {
 
       val retriever = new FilingAttributesBoxValueRetrieverForTest
-      val result = FilingAttributesBoxValueRetriever.generateValues(retriever)
+      val result = BoxValues.generateValues(retriever)
       result("ProductName") shouldBe retriever.retrieveProductName()
       result("FilingCompanyType") shouldBe retriever.retrieveCompanyType()
       result("UTR") shouldBe retriever.retrieveUTR()


### PR DESCRIPTION
This simplifies the code and removes the need to call multiple times into this function from concrete Box Retrievers.