### PR TITLE
CATO-3644 Adding Country of registration

### DIFF
--- a/src/main/scala/uk/gov/hmrc/ct/CountryOfRegistration.scala
+++ b/src/main/scala/uk/gov/hmrc/ct/CountryOfRegistration.scala
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2016 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.ct
+
+import uk.gov.hmrc.ct.box.retriever.FilingAttributesBoxValueRetriever
+import uk.gov.hmrc.ct.box._
+
+case class CountryOfRegistration(value: Option[String]) extends CtBoxIdentifier("Country of registration") with CtOptionalString with Input with ValidatableBox[FilingAttributesBoxValueRetriever] {
+
+  override def validate(boxRetriever: FilingAttributesBoxValueRetriever): Set[CtValidation] = {
+    import CountryOfRegistration._
+    value match {
+      case Some(code) if fromCode(code).isEmpty => Set(CtValidation(boxId= Some("CountryOfRegistration"), errorMessageKey = "error.CountryOfRegistration.unknown"))
+      case _ => Set.empty
+    }
+  }
+}
+
+object CountryOfRegistration {
+
+  val EnglandWales = CountryOfRegistration(Some("EW"))
+  val Scotland = CountryOfRegistration(Some("SC"))
+  val NorthernIreland = CountryOfRegistration(Some("NI"))
+
+  val knownCountries = Set(EnglandWales, Scotland, NorthernIreland)
+
+  def fromCode(code: String): Option[CountryOfRegistration] = knownCountries.find(_.value.contains(code))
+}

--- a/src/main/scala/uk/gov/hmrc/ct/box/retriever/FilingAttributesBoxValueRetriever.scala
+++ b/src/main/scala/uk/gov/hmrc/ct/box/retriever/FilingAttributesBoxValueRetriever.scala
@@ -39,4 +39,6 @@ trait FilingAttributesBoxValueRetriever extends BoxRetriever {
   def retrieveStatutoryAccountsFiling(): StatutoryAccountsFiling
 
   def retrieveUTR(): UTR
+
+  def retrieveCountryOfRegistration(): CountryOfRegistration
 }

--- a/src/main/scala/uk/gov/hmrc/ct/formats/package.scala
+++ b/src/main/scala/uk/gov/hmrc/ct/formats/package.scala
@@ -69,4 +69,5 @@ package object formats {
 
   implicit val cato22Format: Format[CATO22] = new BigDecimalFormat[CATO22](CATO22.apply)
 
+  implicit val CountryOfRegistrationFormat: Format[CountryOfRegistration] = new OptionalStringFormat[CountryOfRegistration](CountryOfRegistration.apply)
 }

--- a/src/test/scala/uk/gov/hmrc/ct/CountryOfRegistrationSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/ct/CountryOfRegistrationSpec.scala
@@ -24,6 +24,7 @@ import uk.gov.hmrc.ct.box.retriever.FilingAttributesBoxValueRetriever
 class CountryOfRegistrationSpec extends WordSpec with Matchers with MockitoSugar {
 
   val boxRetriever = mock[FilingAttributesBoxValueRetriever]
+
   "CountryOfRegistration" should {
     "pass validation if empty" in {
       CountryOfRegistration(None).validate(boxRetriever) shouldBe empty

--- a/src/test/scala/uk/gov/hmrc/ct/CountryOfRegistrationSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/ct/CountryOfRegistrationSpec.scala
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2016 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.ct
+
+import org.scalatest.mock.MockitoSugar
+import org.scalatest.{Matchers, WordSpec}
+import uk.gov.hmrc.ct.box.CtValidation
+import uk.gov.hmrc.ct.box.retriever.FilingAttributesBoxValueRetriever
+
+class CountryOfRegistrationSpec extends WordSpec with Matchers with MockitoSugar {
+
+  val boxRetriever = mock[FilingAttributesBoxValueRetriever]
+  "CountryOfRegistration" should {
+    "pass validation if empty" in {
+      CountryOfRegistration(None).validate(boxRetriever) shouldBe empty
+    }
+    "pass validation for EW" in {
+      CountryOfRegistration(Some("EW")).validate(boxRetriever) shouldBe empty
+    }
+    "pass validation for SC" in {
+      CountryOfRegistration(Some("SC")).validate(boxRetriever) shouldBe empty
+    }
+    "pass validation for IR" in {
+      CountryOfRegistration(Some("NI")).validate(boxRetriever) shouldBe empty
+    }
+    "fail validation for empty string" in {
+      CountryOfRegistration(Some("")).validate(boxRetriever) shouldBe Set(CtValidation(boxId = Some("CountryOfRegistration"), errorMessageKey = "error.CountryOfRegistration.unknown"))
+    }
+    "fail validation for unknown code" in {
+      CountryOfRegistration(Some("AU")).validate(boxRetriever) shouldBe Set(CtValidation(boxId = Some("CountryOfRegistration"), errorMessageKey = "error.CountryOfRegistration.unknown"))
+    }
+  }
+}

--- a/src/test/scala/uk/gov/hmrc/ct/box/retriever/FilingAttributesBoxValueRetrieverSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/ct/box/retriever/FilingAttributesBoxValueRetrieverSpec.scala
@@ -26,7 +26,7 @@ class FilingAttributesBoxValueRetrieverSpec extends WordSpec with Matchers {
 
   "FilingAttributesBoxValueRetriever" should {
     "have 10 functions" in {
-      BoxValues.retrieveBoxIdFunctions(classOf[FilingAttributesBoxValueRetriever]).size shouldBe 10
+      BoxValues.retrieveBoxIdFunctions(classOf[FilingAttributesBoxValueRetriever]).size shouldBe 11
     }
 
     "get ct values" in {
@@ -44,6 +44,7 @@ class FilingAttributesBoxValueRetrieverSpec extends WordSpec with Matchers {
       result("CompaniesHouseFiling") shouldBe retriever.retrieveCompaniesHouseFiling()
       result("HMRCFiling") shouldBe retriever.retrieveHMRCFiling()
       result("HMRCAmendment") shouldBe retriever.retrieveHMRCAmendment()
+      result("CountryOfRegistration") shouldBe retriever.retrieveCountryOfRegistration()
     }
   }
 }
@@ -71,4 +72,6 @@ class FilingAttributesBoxValueRetrieverForTest extends FilingAttributesBoxValueR
   override def retrieveHMRCFiling(): HMRCFiling = HMRCFiling(true)
 
   override def retrieveHMRCAmendment(): HMRCAmendment = HMRCAmendment(false)
+
+  override def retrieveCountryOfRegistration(): CountryOfRegistration = CountryOfRegistration.NorthernIreland
 }

--- a/src/test/scala/uk/gov/hmrc/ct/computations/LowEmissionCarsAcceptanceCriteriaSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/ct/computations/LowEmissionCarsAcceptanceCriteriaSpec.scala
@@ -276,6 +276,6 @@ class LowEmissionCarsAcceptanceCriteriaSpec extends WordSpec with Matchers {
 
     override def retrieveCP668: CP668 = CP668(cp668)
 
-    override def retrieveCountryOfRegistration(): CountryOfRegistration = CountryOfRegistration(Some("EW"))
+    override def retrieveCountryOfRegistration(): CountryOfRegistration = CountryOfRegistration.EnglandWales
   }
 }

--- a/src/test/scala/uk/gov/hmrc/ct/computations/LowEmissionCarsAcceptanceCriteriaSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/ct/computations/LowEmissionCarsAcceptanceCriteriaSpec.scala
@@ -20,6 +20,7 @@ import org.joda.time.LocalDate
 import org.scalatest.prop.TableDrivenPropertyChecks._
 import org.scalatest.prop.Tables.Table
 import org.scalatest.{Matchers, WordSpec}
+import uk.gov.hmrc.ct.CountryOfRegistration
 import uk.gov.hmrc.ct.accounts.retriever.AccountsBoxRetriever
 import uk.gov.hmrc.ct.accounts.stubs.StubbedAccountsBoxRetriever
 import uk.gov.hmrc.ct.computations.stubs.StubbedComputationsBoxRetriever
@@ -274,5 +275,7 @@ class LowEmissionCarsAcceptanceCriteriaSpec extends WordSpec with Matchers {
     override def retrieveCP89: CP89 = CP89(cp89)
 
     override def retrieveCP668: CP668 = CP668(cp668)
+
+    override def retrieveCountryOfRegistration(): CountryOfRegistration = CountryOfRegistration(Some("EW"))
   }
 }

--- a/src/test/scala/uk/gov/hmrc/ct/computations/MachineryAndPlantValidationSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/ct/computations/MachineryAndPlantValidationSpec.scala
@@ -19,7 +19,7 @@ package uk.gov.hmrc.ct.computations
 import org.scalatest.{Matchers, WordSpec}
 import uk.gov.hmrc.ct.box.CtValidation
 import uk.gov.hmrc.ct.computations.stubs.StubbedComputationsBoxRetriever
-import uk.gov.hmrc.ct.{CATO02, CATO20, CATO21, CATO22}
+import uk.gov.hmrc.ct._
 
 class MyStubbedComputationsRetriever(lec01: List[Car] = List(),
                                      cpq8: Option[Boolean] = None,
@@ -94,6 +94,8 @@ class MyStubbedComputationsRetriever(lec01: List[Car] = List(),
   override def retrieveCPAux2: CPAux2 = CPAux2(cpAux2)
 
   override def retrieveCPAux3: CPAux3 = CPAux3(cpAux3)
+
+  override def retrieveCountryOfRegistration(): CountryOfRegistration = CountryOfRegistration.Scotland
 }
 
 

--- a/src/test/scala/uk/gov/hmrc/ct/computations/stubs/StubbedComputationsBoxRetriever.scala
+++ b/src/test/scala/uk/gov/hmrc/ct/computations/stubs/StubbedComputationsBoxRetriever.scala
@@ -21,7 +21,7 @@ import uk.gov.hmrc.ct.box.CtValue
 import uk.gov.hmrc.ct.box.stubs.StubbedFilingAttributesBoxValueRetriever
 import uk.gov.hmrc.ct.computations._
 import uk.gov.hmrc.ct.computations.retriever.ComputationsBoxRetriever
-import uk.gov.hmrc.ct.{CATO11, CATO12}
+import uk.gov.hmrc.ct.{CountryOfRegistration, CATO11, CATO12}
 
 class StubbedComputationsBoxRetriever extends ComputationsBoxRetriever with StubbedAccountsBoxRetriever with StubbedFilingAttributesBoxValueRetriever {
 
@@ -186,4 +186,6 @@ class StubbedComputationsBoxRetriever extends ComputationsBoxRetriever with Stub
   override def retrieveCP252(): CP252 = ???
 
   override def generateValues: Map[String, CtValue[_]] = ???
+
+  override def retrieveCountryOfRegistration(): CountryOfRegistration = CountryOfRegistration.EnglandWales
 }

--- a/src/test/scala/uk/gov/hmrc/ct/ct600/v3/stubs/StubbedCT600BoxRetriever.scala
+++ b/src/test/scala/uk/gov/hmrc/ct/ct600/v3/stubs/StubbedCT600BoxRetriever.scala
@@ -318,5 +318,5 @@ class StubbedCT600BoxRetriever extends CT600BoxRetriever
 
   override def retrieveCP252(): CP252 = ???
 
-  override def retrieveCountryOfRegistration(): CountryOfRegistration = CountryOfRegistration(Some("NI"))
+  override def retrieveCountryOfRegistration(): CountryOfRegistration = ???
 }

--- a/src/test/scala/uk/gov/hmrc/ct/ct600/v3/stubs/StubbedCT600BoxRetriever.scala
+++ b/src/test/scala/uk/gov/hmrc/ct/ct600/v3/stubs/StubbedCT600BoxRetriever.scala
@@ -25,7 +25,7 @@ import uk.gov.hmrc.ct.ct600a.v3._
 import uk.gov.hmrc.ct.ct600a.v3.retriever.CT600ABoxRetriever
 import uk.gov.hmrc.ct.ct600j.v3._
 import uk.gov.hmrc.ct.ct600j.v3.retriever.CT600JBoxRetriever
-import uk.gov.hmrc.ct.{CATO11, CATO10, CATO12}
+import uk.gov.hmrc.ct.{CountryOfRegistration, CATO11, CATO10, CATO12}
 import uk.gov.hmrc.ct.box.CtValue
 import uk.gov.hmrc.ct.ct600.v3.retriever.{CT600DeclarationBoxRetriever, CT600BoxRetriever}
 
@@ -317,4 +317,6 @@ class StubbedCT600BoxRetriever extends CT600BoxRetriever
   override def retrieveB65(): B65 = ???
 
   override def retrieveCP252(): CP252 = ???
+
+  override def retrieveCountryOfRegistration(): CountryOfRegistration = CountryOfRegistration(Some("NI"))
 }

--- a/src/test/scala/uk/gov/hmrc/ct/version/calculations/ReturnVersionsCalculatorSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/ct/version/calculations/ReturnVersionsCalculatorSpec.scala
@@ -94,6 +94,7 @@ class ReturnVersionsCalculatorSpec extends WordSpec with Matchers {
           override def retrieveAbridgedFiling(): AbridgedFiling = AbridgedFiling(false)
           override def retrieveCompaniesHouseFiling(): CompaniesHouseFiling = CompaniesHouseFiling(true)
           override def retrieveHMRCFiling(): HMRCFiling = HMRCFiling(false)
+          override def retrieveCountryOfRegistration(): CountryOfRegistration = CountryOfRegistration(Some("EW"))
         }
 
         ReturnVersionsCalculator.doCalculation(accountsBoxRetriever) shouldBe expectedResult
@@ -1265,4 +1266,6 @@ class ComputationsBoxRetrieverForTest extends StubbedComputationsBoxRetriever wi
   override def retrieveHMRCFiling(): HMRCFiling = HMRCFiling(true)
 
   override def retrieveHMRCAmendment(): HMRCAmendment = HMRCAmendment(false)
+
+  override def retrieveCountryOfRegistration(): CountryOfRegistration = CountryOfRegistration(Some("EW"))
 }

--- a/src/test/scala/uk/gov/hmrc/ct/version/calculations/ReturnVersionsCalculatorSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/ct/version/calculations/ReturnVersionsCalculatorSpec.scala
@@ -1267,5 +1267,5 @@ class ComputationsBoxRetrieverForTest extends StubbedComputationsBoxRetriever wi
 
   override def retrieveHMRCAmendment(): HMRCAmendment = HMRCAmendment(false)
 
-  override def retrieveCountryOfRegistration(): CountryOfRegistration = CountryOfRegistration(Some("EW"))
+  override def retrieveCountryOfRegistration(): CountryOfRegistration = CountryOfRegistration.EnglandWales
 }


### PR DESCRIPTION
This is used to accurately determine accounts text for HMRC and CoHo filings.