### PR TITLE
CATO-3975:changed validation for AC5052A and AC5052B to return a AC52…

### DIFF
--- a/src/main/scala/uk/gov/hmrc/ct/accounts/frs10x/abridged/AC5052A.scala
+++ b/src/main/scala/uk/gov/hmrc/ct/accounts/frs10x/abridged/AC5052A.scala
@@ -24,12 +24,11 @@ import uk.gov.hmrc.ct.box._
 case class AC5052A(value: Option[Int]) extends CtBoxIdentifier(name = "Debtors due after more than one year") with CtOptionalInteger
                                                                                                               with Input
                                                                                                               with ValidatableBox[AbridgedAccountsBoxRetriever]
-
-with Validators {
+                                                                                                              with Validators {
 
   override def validate(boxRetriever: AbridgedAccountsBoxRetriever): Set[CtValidation] = {
     collectErrors (
-      cannotExistIf(value.nonEmpty && !boxRetriever.ac52().value.isDefined),
+      requireIf(value.nonEmpty && !boxRetriever.ac52.value.isDefined)("AC52"),
       validateMoney(value, min = 0)
     )
   }

--- a/src/main/scala/uk/gov/hmrc/ct/accounts/frs10x/abridged/AC5052B.scala
+++ b/src/main/scala/uk/gov/hmrc/ct/accounts/frs10x/abridged/AC5052B.scala
@@ -27,7 +27,7 @@ case class AC5052B(value: Option[String]) extends CtBoxIdentifier(name = "Balanc
 
   override def validate(boxRetriever: AbridgedAccountsBoxRetriever): Set[CtValidation] = {
     collectErrors (
-      cannotExistIf(value.nonEmpty && !boxRetriever.ac52().value.isDefined),
+      requireIf(value.nonEmpty && !boxRetriever.ac52.value.isDefined)("AC52"),
       validateStringMaxLength("AC5052B", value.getOrElse(""), 20000),
       validateOptionalStringByRegex("AC5052B", this, validCoHoCharacters)
     )

--- a/src/main/scala/uk/gov/hmrc/ct/box/Validators.scala
+++ b/src/main/scala/uk/gov/hmrc/ct/box/Validators.scala
@@ -41,6 +41,13 @@ trait Validators {
         Set.empty
   }
 
+  protected def requireIf(predicate: => Boolean)(boxId:String)(): Set[CtValidation] = {
+    if (predicate)
+      Set(CtValidation(Some(boxId), s"error.$boxId.required"))
+    else
+      Set.empty
+  }
+
   protected def exceedsMax(value: Option[Int], max: Int = MAX_MONEY_AMOUNT_ALLOWED)(): Set[CtValidation] = {
     value match {
       case (Some(v)) if v > max => Set(CtValidation(Some(boxId), s"error.$boxId.exceeds.max", Some(Seq(max.toString))))

--- a/src/test/scala/uk/gov/hmrc/ct/accounts/frs10x/abridged/AC5052ASpec.scala
+++ b/src/test/scala/uk/gov/hmrc/ct/accounts/frs10x/abridged/AC5052ASpec.scala
@@ -31,8 +31,8 @@ class AC5052ASpec extends WordSpec with MockitoSugar with Matchers with MockAbri
 
   testAccountsMoneyValidationWithMin("AC5052A", minValue = 0, AC5052A)
 
-  "fail validation when populated and AC52 is empty" in {
+  "returns AC52 required validation error when AC5052A populated and AC52 is empty" in {
     when(boxRetriever.ac52()).thenReturn(AC52(None))
-    AC5052A(Some(4)).validate(boxRetriever) shouldBe Set(CtValidation(Some("AC5052A"), "error.AC5052A.cannot.exist"))
-  }
+    AC5052A(Some(4)).validate(boxRetriever) shouldBe Set(CtValidation(Some("AC52"), "error.AC52.required"))
+   }
 }

--- a/src/test/scala/uk/gov/hmrc/ct/accounts/frs10x/abridged/AC5052BSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/ct/accounts/frs10x/abridged/AC5052BSpec.scala
@@ -34,9 +34,9 @@ class AC5052BSpec extends WordSpec with MockitoSugar with Matchers with BeforeAn
 
   "AC5052B" should {
 
-    "fail validation when populated and AC52 is empty" in {
+    "returns AC52 required validation error when AC5052B populated and AC52 is empty" in {
       when(boxRetriever.ac52()).thenReturn(AC52(None))
-      AC5052B(Some("test text")).validate(boxRetriever) shouldBe Set(CtValidation(Some("AC5052B"), "error.AC5052B.cannot.exist"))
+      AC5052B(Some("text")).validate(boxRetriever) shouldBe Set(CtValidation(Some("AC52"), "error.AC52.required"))
     }
   }
 }


### PR DESCRIPTION
… required error instead of AC5052A and AC5052B cannot exist