### PR TITLE
Cato 4027 validatable box semplification

### DIFF
--- a/src/main/scala/uk/gov/hmrc/ct/accounts/frs10x/AC8021.scala
+++ b/src/main/scala/uk/gov/hmrc/ct/accounts/frs10x/AC8021.scala
@@ -20,7 +20,7 @@ import uk.gov.hmrc.ct.accounts.frs10x.retriever.Frs10xDirectorsBoxRetriever
 import uk.gov.hmrc.ct.box._
 import uk.gov.hmrc.ct.box.retriever.FilingAttributesBoxValueRetriever
 
-case class AC8021(value: Option[Boolean]) extends CtBoxIdentifier(name = "Do you want to file a directors' report to Companies House?") with CtOptionalBoolean with Input with ValidatableBox[Frs10xDirectorsBoxRetriever with FilingAttributesBoxValueRetriever] {
+case class AC8021(value: Option[Boolean]) extends CtBoxIdentifier(name = "Do you want to file a directors' report to Companies House?") with CtOptionalBoolean with Input with SelfValidatableBox[Frs10xDirectorsBoxRetriever with FilingAttributesBoxValueRetriever, Option[Boolean]] {
   override def validate(boxRetriever: Frs10xDirectorsBoxRetriever with FilingAttributesBoxValueRetriever): Set[CtValidation] = {
     val coHoFiling = boxRetriever.companiesHouseFiling().value
     val hmrcFiling = boxRetriever.hmrcFiling().value
@@ -31,7 +31,7 @@ case class AC8021(value: Option[Boolean]) extends CtBoxIdentifier(name = "Do you
     // or when filing Joint micro-entity AND answered "true" to "AC8023".
     // In the last case, answering "false" disables "Directors report" section - including this question.
     if (coHoFiling && (!(hmrcFiling && microEntityFiling) || (hmrcFiling && microEntityFiling && fileDRToHmrc)))
-      validateBooleanAsMandatory("AC8021", this)
+      validateBooleanAsMandatory()
     else
       Set.empty
   }

--- a/src/main/scala/uk/gov/hmrc/ct/accounts/frs10x/abridged/AC106A.scala
+++ b/src/main/scala/uk/gov/hmrc/ct/accounts/frs10x/abridged/AC106A.scala
@@ -32,7 +32,7 @@ case class AC106A(value: Option[String]) extends CtBoxIdentifier(name = "Employe
     collectErrors (
       cannotExistIf(!noteSelectedForInclusion && value.nonEmpty),
       validateStringMaxLength(value.getOrElse(""), StandardCohoTextFieldLimit),
-      validateCoHoOptionalTextField()
+      validateCoHoOptionalString()
     )
   }
 }

--- a/src/main/scala/uk/gov/hmrc/ct/accounts/frs10x/abridged/AC106A.scala
+++ b/src/main/scala/uk/gov/hmrc/ct/accounts/frs10x/abridged/AC106A.scala
@@ -23,17 +23,16 @@ import uk.gov.hmrc.ct.box.ValidatableBox._
 case class AC106A(value: Option[String]) extends CtBoxIdentifier(name = "Employees note additional information")
   with CtOptionalString
   with Input
-  with ValidatableBox[AbridgedAccountsBoxRetriever]
+  with SelfValidatableBox[AbridgedAccountsBoxRetriever, Option[String]]
   with Validators {
-
 
   override def validate(boxRetriever: AbridgedAccountsBoxRetriever): Set[CtValidation] = {
     val noteSelectedForInclusion = boxRetriever.ac7300().orFalse
 
     collectErrors (
       cannotExistIf(!noteSelectedForInclusion && value.nonEmpty),
-      validateStringMaxLength("AC106A", value.getOrElse(""), StandardCohoTextFieldLimit),
-      validateCoHoOptionalTextField("AC106A", this)
+      validateStringMaxLength(value.getOrElse(""), StandardCohoTextFieldLimit),
+      validateCoHoOptionalTextField()
     )
   }
 }

--- a/src/main/scala/uk/gov/hmrc/ct/accounts/frs10x/abridged/AC320A.scala
+++ b/src/main/scala/uk/gov/hmrc/ct/accounts/frs10x/abridged/AC320A.scala
@@ -23,7 +23,7 @@ import uk.gov.hmrc.ct.box.ValidatableBox._
 case class AC320A(value: Option[String]) extends CtBoxIdentifier(name = "Basis of measurement and preparation")
                                       with CtOptionalString
                                       with Input
-                                      with ValidatableBox[AbridgedAccountsBoxRetriever]
+                                      with SelfValidatableBox[AbridgedAccountsBoxRetriever, Option[String]]
                                       with Validators {
 
 
@@ -31,8 +31,8 @@ case class AC320A(value: Option[String]) extends CtBoxIdentifier(name = "Basis o
     collectErrors(
       cannotExistIf(value.isDefined && boxRetriever.ac320().value.contains(true)),
       requiredIf(value.isEmpty && boxRetriever.ac320.value.contains(false)),
-      validateStringMaxLength("AC320A", value.getOrElse(""), StandardCohoTextFieldLimit),
-      validateCoHoOptionalTextField("AC320A", this)
+      validateStringMaxLength(value.getOrElse(""), StandardCohoTextFieldLimit),
+      validateCoHoOptionalTextField()
     )
   }
 }

--- a/src/main/scala/uk/gov/hmrc/ct/accounts/frs10x/abridged/AC7901.scala
+++ b/src/main/scala/uk/gov/hmrc/ct/accounts/frs10x/abridged/AC7901.scala
@@ -22,7 +22,7 @@ import uk.gov.hmrc.ct.box._
 
 case class AC7901(value: Option[String]) extends CtBoxIdentifier(name = "Post balance sheet events") with CtOptionalString
 with Input
-with ValidatableBox[AbridgedAccountsBoxRetriever]
+with SelfValidatableBox[AbridgedAccountsBoxRetriever, Option[String]]
 with Validators {
 
   override def validate(boxRetriever: AbridgedAccountsBoxRetriever): Set[CtValidation] = {
@@ -31,9 +31,9 @@ with Validators {
 
       failIf (boxRetriever.ac7900().orFalse) (
         collectErrors (
-          validateStringAsMandatory("AC7901", this),
-          validateOptionalStringByLength("AC7901", this, 1, StandardCohoTextFieldLimit),
-          validateCoHoOptionalString("AC7901", this)
+          validateStringAsMandatory(),
+          validateOptionalStringByLength(1, StandardCohoTextFieldLimit),
+          validateCoHoOptionalString()
         )
       )
     )

--- a/src/main/scala/uk/gov/hmrc/ct/box/SelfValidatableBox.scala
+++ b/src/main/scala/uk/gov/hmrc/ct/box/SelfValidatableBox.scala
@@ -1,0 +1,165 @@
+/*
+ * Copyright 2016 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.ct.box
+
+import org.joda.time.LocalDate
+import uk.gov.hmrc.ct.box.retriever.BoxRetriever
+import uk.gov.hmrc.ct.ct600.v3.retriever.RepaymentsBoxRetriever
+import uk.gov.hmrc.ct.domain.ValidationConstants._
+import uk.gov.hmrc.ct.utils.DateImplicits._
+import ValidatableBox._
+
+
+trait SelfValidatableBox[T <: BoxRetriever, B] extends Validators with ValidatableBox[T]{
+
+  box: CtValue[B] with CtBoxIdentifier =>
+
+  // Taken from PostCodeType on http://www.hmrc.gov.uk/schemas/core-v2-0.xsd
+  private val postCodeRegex = """(GIR 0AA)|((([A-Z][0-9][0-9]?)|(([A-Z][A-HJ-Y][0-9][0-9]?)|(([A-Z][0-9][A-Z])|([A-Z][A-HJ-Y][0-9]?[A-Z])))) [0-9][A-Z]{2})"""
+
+  def validate(boxRetriever: T): Set[CtValidation]
+
+  protected def validateBooleanAsMandatory()(): Set[CtValidation] = {
+    super.validateBooleanAsMandatory(box.id, box.asInstanceOf[CtValue[Option[Boolean]] with CtBoxIdentifier])
+  }
+
+  protected def validateIntegerAsMandatory()(): Set[CtValidation] = {
+    super.validateIntegerAsMandatory(box.id, box.asInstanceOf[CtValue[Option[Int]] with CtBoxIdentifier])
+  }
+
+  protected def validateStringAsMandatory()()(implicit ev: <:<[B, String]): Set[CtValidation] = {
+    super.validateStringAsMandatory(box.id, box.asInstanceOf[CtValue[Option[String]] with CtBoxIdentifier])
+  }
+
+  protected def validateAsMandatory()(): Set[CtValidation] = {
+    validateAsMandatory(box)
+  }
+
+  protected def validateStringAsMandatoryIfPAYEEQ1False(boxRetriever: RepaymentsBoxRetriever)(): Set[CtValidation] = {
+    super.validateStringAsMandatoryIfPAYEEQ1False(boxRetriever, box.id, box.asInstanceOf[CtValue[Option[String]] with CtBoxIdentifier])
+  }
+
+  protected def validateAllFilledOrEmptyStrings(allBoxes: Set[CtValue[String]])(): Set[CtValidation] = {
+    super.validateAllFilledOrEmptyStrings(box.id, allBoxes)
+  }
+
+  protected def validateAllFilledOrEmptyStringsForBankDetails(boxRetriever: RepaymentsBoxRetriever)(): Set[CtValidation] = {
+    super.validateAllFilledOrEmptyStringsForBankDetails(boxRetriever, box.id)
+  }
+
+  protected def validateStringAsBlank()(): Set[CtValidation] = {
+    super.validateStringAsBlank(box.id, box.asInstanceOf[CtValue[Option[String]] with CtBoxIdentifier])
+  }
+
+  protected def validateDateAsMandatory()(): Set[CtValidation] = {
+    super.validateDateAsMandatory(box.id, box.value.asInstanceOf[Option[LocalDate]], box.id): Set[CtValidation]
+  }
+
+  protected def validateDateAsMandatory(date: Option[LocalDate], messageId: String)(): Set[CtValidation] = {
+    super.validateDateAsMandatory(box.id, date, messageId)
+  }
+
+  protected def validateDateAsBlank()(): Set[CtValidation] = {
+    super.validateDateAsBlank(box.id, box.asInstanceOf[CtValue[Option[LocalDate]] with CtBoxIdentifier])
+  }
+
+  protected def validateDateAsBefore(dateToCompare: LocalDate)(): Set[CtValidation] = {
+    super.validateDateAsBefore(box.id, box.asInstanceOf[CtValue[Option[LocalDate]] with CtBoxIdentifier], dateToCompare)
+  }
+
+  protected def validateDateAsAfter(dateToCompare: LocalDate)(): Set[CtValidation] = {
+    super.validateDateAsAfter(box.id, box.asInstanceOf[CtValue[Option[LocalDate]] with CtBoxIdentifier], dateToCompare)
+  }
+
+  protected def validateDateAsBetweenInclusive(minDate: LocalDate, maxDate: LocalDate)(): Set[CtValidation] = {
+    validateDateAsBetweenInclusive(box.value.asInstanceOf[Option[LocalDate]], minDate, maxDate, box.id)
+  }
+
+  protected def validateDateAsBetweenInclusive(date: Option[LocalDate], minDate: LocalDate, maxDate: LocalDate, messageId: String)(): Set[CtValidation] = {
+    super.validateDateAsBetweenInclusive(box.id, date, minDate, maxDate, messageId)
+  }
+
+  protected def validateIntegerAsBlank()(): Set[CtValidation] = {
+    super.validateIntegerAsBlank(box.id, box.asInstanceOf[CtValue[Option[Int]] with CtBoxIdentifier])
+  }
+
+  protected def validateIntegerRange(min: Int = 0, max: Int)(): Set[CtValidation] = {
+    super.validateIntegerRange(box.id, box.asInstanceOf[CtValue[Option[Int]] with CtBoxIdentifier], min, max)
+  }
+
+  protected def validateZeroOrPositiveBigDecimal()(): Set[CtValidation] = {
+    super.validateZeroOrPositiveBigDecimal(box.asInstanceOf[CtValue[Option[BigDecimal]] with CtBoxIdentifier])
+  }
+
+  protected def validateZeroOrPositiveInteger()(): Set[CtValidation] = {
+    super.validateZeroOrPositiveInteger(box.asInstanceOf[CtValue[Option[Int]] with CtBoxIdentifier])
+  }
+
+  protected def validatePositiveBigDecimal()(): Set[CtValidation] = {
+    super.validatePositiveBigDecimal(box.asInstanceOf[CtValue[Option[BigDecimal]] with CtBoxIdentifier])
+  }
+
+  protected def validatePositiveInteger()(): Set[CtValidation] = {
+    super.validatePositiveInteger(box.asInstanceOf[CtValue[Option[Int]] with CtBoxIdentifier])
+  }
+
+  protected def validateOptionalIntegerAsEqualTo(equalToBox: CtBoxIdentifier with CtOptionalInteger): Set[CtValidation] = {
+    super.validateOptionalIntegerAsEqualTo(box.asInstanceOf[CtBoxIdentifier with CtOptionalInteger], equalToBox)
+  }
+
+  protected def validateOptionalStringByRegex(regex: String)()(implicit ev: <:<[B, String]): Set[CtValidation] = {
+    super.validateOptionalStringByRegex(box.id, box.asInstanceOf[CtValue[Option[String]] with CtBoxIdentifier], regex)
+  }
+
+  protected def validateCoHoOptionalTextField()(): Set[CtValidation] = {
+    super.validateCoHoOptionalTextField(box.id, box.asInstanceOf[CtValue[Option[String]] with CtBoxIdentifier])
+  }
+
+  protected def validateStringByRegex(boxValue: CtString, regex: String)(): Set[CtValidation] = {
+    super.validateStringByRegex(box.id, boxValue, regex)
+  }
+
+  protected def validateRawStringByRegex(value: String, errorCodeBoxId: String, regex: String)(): Set[CtValidation] = {
+    super.validateRawStringByRegex(box.id, value, errorCodeBoxId, regex)
+  }
+
+  protected def validateOptionalStringByLength(min: Int, max: Int)()(implicit ev: <:<[B, String]): Set[CtValidation] = {
+    super.validateOptionalStringByLength(box.id, box.asInstanceOf[CtValue[Option[String]] with CtBoxIdentifier], min, max)
+  }
+
+  protected def validateStringByLength(boxValue: CtString, min:Int, max:Int)(): Set[CtValidation] = {
+    super.validateStringByLength(box.id, boxValue, min, max)
+  }
+
+  def validateNotEmptyStringByLength(value: String, min: Int, max: Int)(): Set[CtValidation] = {
+    super.validateNotEmptyStringByLength(box.id, value, min, max)
+  }
+
+  def validateStringByLength(value: String, errorCodeId: String, min: Int, max: Int)(): Set[CtValidation] = {
+    super.validateStringByLength(box.id, value, errorCodeId, min, max)
+  }
+
+  def validateStringMaxLength(value: String, max: Int)(): Set[CtValidation] = {
+    super.validateStringMaxLength(box.id, value, max)
+  }
+
+  def validatePostcode(boxId: String)(): Set[CtValidation] = {
+    super.validatePostcode(box.id, box.asInstanceOf[CtValue[Option[String]] with CtBoxIdentifier])
+  }
+
+}
+

--- a/src/main/scala/uk/gov/hmrc/ct/box/SelfValidatableBox.scala
+++ b/src/main/scala/uk/gov/hmrc/ct/box/SelfValidatableBox.scala
@@ -34,15 +34,19 @@ trait SelfValidatableBox[T <: BoxRetriever, B] extends Validators with Validatab
   def validate(boxRetriever: T): Set[CtValidation]
 
   protected def validateBooleanAsMandatory()(): Set[CtValidation] = {
-    super.validateBooleanAsMandatory(box.id, box.asInstanceOf[CtValue[Option[Boolean]] with CtBoxIdentifier])
+    super.validateBooleanAsMandatory(box.id, box.asInstanceOf[OptionalBooleanIdBox])
+  }
+
+  protected def validateBooleanAsTrue()(): Set[CtValidation] = {
+    super.validateBooleanAsTrue(box.id, box.asInstanceOf[OptionalBooleanIdBox])
   }
 
   protected def validateIntegerAsMandatory()(): Set[CtValidation] = {
-    super.validateIntegerAsMandatory(box.id, box.asInstanceOf[CtValue[Option[Int]] with CtBoxIdentifier])
+    super.validateIntegerAsMandatory(box.id, box.asInstanceOf[OptionalIntIdBox])
   }
 
   protected def validateStringAsMandatory()()(implicit ev: <:<[B, String]): Set[CtValidation] = {
-    super.validateStringAsMandatory(box.id, box.asInstanceOf[CtValue[Option[String]] with CtBoxIdentifier])
+    super.validateStringAsMandatory(box.id, box.asInstanceOf[OptionalStringIdBox])
   }
 
   protected def validateAsMandatory()(): Set[CtValidation] = {
@@ -50,7 +54,7 @@ trait SelfValidatableBox[T <: BoxRetriever, B] extends Validators with Validatab
   }
 
   protected def validateStringAsMandatoryIfPAYEEQ1False(boxRetriever: RepaymentsBoxRetriever)(): Set[CtValidation] = {
-    super.validateStringAsMandatoryIfPAYEEQ1False(boxRetriever, box.id, box.asInstanceOf[CtValue[Option[String]] with CtBoxIdentifier])
+    super.validateStringAsMandatoryIfPAYEEQ1False(boxRetriever, box.id, box.asInstanceOf[OptionalStringIdBox])
   }
 
   protected def validateAllFilledOrEmptyStrings(allBoxes: Set[CtValue[String]])(): Set[CtValidation] = {
@@ -62,7 +66,7 @@ trait SelfValidatableBox[T <: BoxRetriever, B] extends Validators with Validatab
   }
 
   protected def validateStringAsBlank()(): Set[CtValidation] = {
-    super.validateStringAsBlank(box.id, box.asInstanceOf[CtValue[Option[String]] with CtBoxIdentifier])
+    super.validateStringAsBlank(box.id, box.asInstanceOf[OptionalStringIdBox])
   }
 
   protected def validateDateAsMandatory()(): Set[CtValidation] = {
@@ -74,15 +78,15 @@ trait SelfValidatableBox[T <: BoxRetriever, B] extends Validators with Validatab
   }
 
   protected def validateDateAsBlank()(): Set[CtValidation] = {
-    super.validateDateAsBlank(box.id, box.asInstanceOf[CtValue[Option[LocalDate]] with CtBoxIdentifier])
+    super.validateDateAsBlank(box.id, box.asInstanceOf[OptionalDateIdBox])
   }
 
   protected def validateDateAsBefore(dateToCompare: LocalDate)(): Set[CtValidation] = {
-    super.validateDateAsBefore(box.id, box.asInstanceOf[CtValue[Option[LocalDate]] with CtBoxIdentifier], dateToCompare)
+    super.validateDateAsBefore(box.id, box.asInstanceOf[OptionalDateIdBox], dateToCompare)
   }
 
   protected def validateDateAsAfter(dateToCompare: LocalDate)(): Set[CtValidation] = {
-    super.validateDateAsAfter(box.id, box.asInstanceOf[CtValue[Option[LocalDate]] with CtBoxIdentifier], dateToCompare)
+    super.validateDateAsAfter(box.id, box.asInstanceOf[OptionalDateIdBox], dateToCompare)
   }
 
   protected def validateDateAsBetweenInclusive(minDate: LocalDate, maxDate: LocalDate)(): Set[CtValidation] = {
@@ -94,27 +98,27 @@ trait SelfValidatableBox[T <: BoxRetriever, B] extends Validators with Validatab
   }
 
   protected def validateIntegerAsBlank()(): Set[CtValidation] = {
-    super.validateIntegerAsBlank(box.id, box.asInstanceOf[CtValue[Option[Int]] with CtBoxIdentifier])
+    super.validateIntegerAsBlank(box.id, box.asInstanceOf[OptionalIntIdBox])
   }
 
   protected def validateIntegerRange(min: Int = 0, max: Int)(): Set[CtValidation] = {
-    super.validateIntegerRange(box.id, box.asInstanceOf[CtValue[Option[Int]] with CtBoxIdentifier], min, max)
+    super.validateIntegerRange(box.id, box.asInstanceOf[OptionalIntIdBox], min, max)
   }
 
   protected def validateZeroOrPositiveBigDecimal()(): Set[CtValidation] = {
-    super.validateZeroOrPositiveBigDecimal(box.asInstanceOf[CtValue[Option[BigDecimal]] with CtBoxIdentifier])
+    super.validateZeroOrPositiveBigDecimal(box.asInstanceOf[OptionalBigDecimalIdBox])
   }
 
   protected def validateZeroOrPositiveInteger()(): Set[CtValidation] = {
-    super.validateZeroOrPositiveInteger(box.asInstanceOf[CtValue[Option[Int]] with CtBoxIdentifier])
+    super.validateZeroOrPositiveInteger(box.asInstanceOf[OptionalIntIdBox])
   }
 
   protected def validatePositiveBigDecimal()(): Set[CtValidation] = {
-    super.validatePositiveBigDecimal(box.asInstanceOf[CtValue[Option[BigDecimal]] with CtBoxIdentifier])
+    super.validatePositiveBigDecimal(box.asInstanceOf[OptionalBigDecimalIdBox])
   }
 
   protected def validatePositiveInteger()(): Set[CtValidation] = {
-    super.validatePositiveInteger(box.asInstanceOf[CtValue[Option[Int]] with CtBoxIdentifier])
+    super.validatePositiveInteger(box.asInstanceOf[OptionalIntIdBox])
   }
 
   protected def validateOptionalIntegerAsEqualTo(equalToBox: CtBoxIdentifier with CtOptionalInteger): Set[CtValidation] = {
@@ -122,23 +126,35 @@ trait SelfValidatableBox[T <: BoxRetriever, B] extends Validators with Validatab
   }
 
   protected def validateOptionalStringByRegex(regex: String)()(implicit ev: <:<[B, String]): Set[CtValidation] = {
-    super.validateOptionalStringByRegex(box.id, box.asInstanceOf[CtValue[Option[String]] with CtBoxIdentifier], regex)
-  }
-
-  protected def validateCoHoOptionalTextField()(): Set[CtValidation] = {
-    super.validateCoHoOptionalTextField(box.id, box.asInstanceOf[CtValue[Option[String]] with CtBoxIdentifier])
-  }
-
-  protected def validateStringByRegex(boxValue: CtString, regex: String)(): Set[CtValidation] = {
-    super.validateStringByRegex(box.id, boxValue, regex)
+    super.validateOptionalStringByRegex(box.id, box.asInstanceOf[OptionalStringIdBox], regex)
   }
 
   protected def validateRawStringByRegex(value: String, errorCodeBoxId: String, regex: String)(): Set[CtValidation] = {
     super.validateRawStringByRegex(box.id, value, errorCodeBoxId, regex)
   }
 
+  protected def validateStringByRegex(regex: String)(): Set[CtValidation] = {
+    super.validateStringByRegex(box.id, box.asInstanceOf[StringIdBox], regex)
+  }
+
+  protected def validateCoHoOptionalString()(): Set[CtValidation] = {
+    super.validateCoHoOptionalString(box.id, box.asInstanceOf[OptionalStringIdBox])
+  }
+
+  protected def validateCohoNameField()(): Set[CtValidation] = {
+    super.validateCohoNameField(box.id, box.asInstanceOf[StringIdBox])
+  }
+
+  protected def validateCohoOptionalNameField()(): Set[CtValidation] = {
+    super.validateCohoOptionalNameField(box.id, box.asInstanceOf[OptionalStringIdBox])
+  }
+
+  protected def validateCoHoString(value: String, errorCodeBoxId: Option[String])(): Set[CtValidation] = {
+    super.validateCoHoString(box.id, value, errorCodeBoxId)
+  }
+
   protected def validateOptionalStringByLength(min: Int, max: Int)()(implicit ev: <:<[B, String]): Set[CtValidation] = {
-    super.validateOptionalStringByLength(box.id, box.asInstanceOf[CtValue[Option[String]] with CtBoxIdentifier], min, max)
+    super.validateOptionalStringByLength(box.id, box.asInstanceOf[OptionalStringIdBox], min, max)
   }
 
   protected def validateStringByLength(boxValue: CtString, min:Int, max:Int)(): Set[CtValidation] = {
@@ -158,7 +174,7 @@ trait SelfValidatableBox[T <: BoxRetriever, B] extends Validators with Validatab
   }
 
   def validatePostcode(boxId: String)(): Set[CtValidation] = {
-    super.validatePostcode(box.id, box.asInstanceOf[CtValue[Option[String]] with CtBoxIdentifier])
+    super.validatePostcode(box.id, box.asInstanceOf[OptionalStringIdBox])
   }
 
 }

--- a/src/main/scala/uk/gov/hmrc/ct/box/SelfValidatableBox.scala
+++ b/src/main/scala/uk/gov/hmrc/ct/box/SelfValidatableBox.scala
@@ -28,24 +28,21 @@ trait SelfValidatableBox[T <: BoxRetriever, B] extends Validators with Validatab
 
   box: CtValue[B] with CtBoxIdentifier =>
 
-  // Taken from PostCodeType on http://www.hmrc.gov.uk/schemas/core-v2-0.xsd
-  private val postCodeRegex = """(GIR 0AA)|((([A-Z][0-9][0-9]?)|(([A-Z][A-HJ-Y][0-9][0-9]?)|(([A-Z][0-9][A-Z])|([A-Z][A-HJ-Y][0-9]?[A-Z])))) [0-9][A-Z]{2})"""
-
   def validate(boxRetriever: T): Set[CtValidation]
 
-  protected def validateBooleanAsMandatory()(): Set[CtValidation] = {
+  protected def validateBooleanAsMandatory()()(implicit ev: <:<[B, Option[Boolean]]): Set[CtValidation] = {
     super.validateBooleanAsMandatory(box.id, box.asInstanceOf[OptionalBooleanIdBox])
   }
 
-  protected def validateBooleanAsTrue()(): Set[CtValidation] = {
+  protected def validateBooleanAsTrue()()(implicit ev: <:<[B, Option[Boolean]]): Set[CtValidation] = {
     super.validateBooleanAsTrue(box.id, box.asInstanceOf[OptionalBooleanIdBox])
   }
 
-  protected def validateIntegerAsMandatory()(): Set[CtValidation] = {
+  protected def validateIntegerAsMandatory()()(implicit ev: <:<[B, Option[Int]]): Set[CtValidation] = {
     super.validateIntegerAsMandatory(box.id, box.asInstanceOf[OptionalIntIdBox])
   }
 
-  protected def validateStringAsMandatory()()(implicit ev: <:<[B, String]): Set[CtValidation] = {
+  protected def validateStringAsMandatory()()(implicit ev: <:<[B, Option[String]]): Set[CtValidation] = {
     super.validateStringAsMandatory(box.id, box.asInstanceOf[OptionalStringIdBox])
   }
 
@@ -53,7 +50,7 @@ trait SelfValidatableBox[T <: BoxRetriever, B] extends Validators with Validatab
     validateAsMandatory(box)
   }
 
-  protected def validateStringAsMandatoryIfPAYEEQ1False(boxRetriever: RepaymentsBoxRetriever)(): Set[CtValidation] = {
+  protected def validateStringAsMandatoryIfPAYEEQ1False(boxRetriever: RepaymentsBoxRetriever)()(implicit ev: <:<[B, Option[String]]): Set[CtValidation] = {
     super.validateStringAsMandatoryIfPAYEEQ1False(boxRetriever, box.id, box.asInstanceOf[OptionalStringIdBox])
   }
 
@@ -65,11 +62,11 @@ trait SelfValidatableBox[T <: BoxRetriever, B] extends Validators with Validatab
     super.validateAllFilledOrEmptyStringsForBankDetails(boxRetriever, box.id)
   }
 
-  protected def validateStringAsBlank()(): Set[CtValidation] = {
+  protected def validateStringAsBlank()()(implicit ev: <:<[B, Option[String]]): Set[CtValidation] = {
     super.validateStringAsBlank(box.id, box.asInstanceOf[OptionalStringIdBox])
   }
 
-  protected def validateDateAsMandatory()(): Set[CtValidation] = {
+  protected def validateDateAsMandatory()()(implicit ev: <:<[B, Option[LocalDate]]): Set[CtValidation] = {
     super.validateDateAsMandatory(box.id, box.value.asInstanceOf[Option[LocalDate]], box.id): Set[CtValidation]
   }
 
@@ -77,19 +74,19 @@ trait SelfValidatableBox[T <: BoxRetriever, B] extends Validators with Validatab
     super.validateDateAsMandatory(box.id, date, messageId)
   }
 
-  protected def validateDateAsBlank()(): Set[CtValidation] = {
+  protected def validateDateAsBlank()()(implicit ev: <:<[B, Option[LocalDate]]): Set[CtValidation] = {
     super.validateDateAsBlank(box.id, box.asInstanceOf[OptionalDateIdBox])
   }
 
-  protected def validateDateAsBefore(dateToCompare: LocalDate)(): Set[CtValidation] = {
+  protected def validateDateAsBefore(dateToCompare: LocalDate)()(implicit ev: <:<[B, Option[LocalDate]]): Set[CtValidation] = {
     super.validateDateAsBefore(box.id, box.asInstanceOf[OptionalDateIdBox], dateToCompare)
   }
 
-  protected def validateDateAsAfter(dateToCompare: LocalDate)(): Set[CtValidation] = {
+  protected def validateDateAsAfter(dateToCompare: LocalDate)()(implicit ev: <:<[B, Option[LocalDate]]): Set[CtValidation] = {
     super.validateDateAsAfter(box.id, box.asInstanceOf[OptionalDateIdBox], dateToCompare)
   }
 
-  protected def validateDateAsBetweenInclusive(minDate: LocalDate, maxDate: LocalDate)(): Set[CtValidation] = {
+  protected def validateDateAsBetweenInclusive(minDate: LocalDate, maxDate: LocalDate)()(implicit ev: <:<[B, Option[LocalDate]]): Set[CtValidation] = {
     validateDateAsBetweenInclusive(box.value.asInstanceOf[Option[LocalDate]], minDate, maxDate, box.id)
   }
 
@@ -97,35 +94,35 @@ trait SelfValidatableBox[T <: BoxRetriever, B] extends Validators with Validatab
     super.validateDateAsBetweenInclusive(box.id, date, minDate, maxDate, messageId)
   }
 
-  protected def validateIntegerAsBlank()(): Set[CtValidation] = {
+  protected def validateIntegerAsBlank()()(implicit ev: <:<[B, Option[Int]]): Set[CtValidation] = {
     super.validateIntegerAsBlank(box.id, box.asInstanceOf[OptionalIntIdBox])
   }
 
-  protected def validateIntegerRange(min: Int = 0, max: Int)(): Set[CtValidation] = {
+  protected def validateIntegerRange(min: Int = 0, max: Int)()(implicit ev: <:<[B, Option[Int]]): Set[CtValidation] = {
     super.validateIntegerRange(box.id, box.asInstanceOf[OptionalIntIdBox], min, max)
   }
 
-  protected def validateZeroOrPositiveBigDecimal()(): Set[CtValidation] = {
+  protected def validateZeroOrPositiveBigDecimal()()(implicit ev: <:<[B, Option[BigDecimal]]): Set[CtValidation] = {
     super.validateZeroOrPositiveBigDecimal(box.asInstanceOf[OptionalBigDecimalIdBox])
   }
 
-  protected def validateZeroOrPositiveInteger()(): Set[CtValidation] = {
+  protected def validateZeroOrPositiveInteger()()(implicit ev: <:<[B, Option[Int]]): Set[CtValidation] = {
     super.validateZeroOrPositiveInteger(box.asInstanceOf[OptionalIntIdBox])
   }
 
-  protected def validatePositiveBigDecimal()(): Set[CtValidation] = {
+  protected def validatePositiveBigDecimal()()(implicit ev: <:<[B, Option[BigDecimal]]): Set[CtValidation] = {
     super.validatePositiveBigDecimal(box.asInstanceOf[OptionalBigDecimalIdBox])
   }
 
-  protected def validatePositiveInteger()(): Set[CtValidation] = {
+  protected def validatePositiveInteger()()(implicit ev: <:<[B, Option[Int]]): Set[CtValidation] = {
     super.validatePositiveInteger(box.asInstanceOf[OptionalIntIdBox])
   }
 
-  protected def validateOptionalIntegerAsEqualTo(equalToBox: CtBoxIdentifier with CtOptionalInteger): Set[CtValidation] = {
+  protected def validateOptionalIntegerAsEqualTo(equalToBox: CtBoxIdentifier with CtOptionalInteger)(implicit ev: <:<[B, CtBoxIdentifier with CtOptionalInteger]): Set[CtValidation] = {
     super.validateOptionalIntegerAsEqualTo(box.asInstanceOf[CtBoxIdentifier with CtOptionalInteger], equalToBox)
   }
 
-  protected def validateOptionalStringByRegex(regex: String)()(implicit ev: <:<[B, String]): Set[CtValidation] = {
+  protected def validateOptionalStringByRegex(regex: String)()(implicit ev: <:<[B, Option[String]]): Set[CtValidation] = {
     super.validateOptionalStringByRegex(box.id, box.asInstanceOf[OptionalStringIdBox], regex)
   }
 
@@ -133,19 +130,19 @@ trait SelfValidatableBox[T <: BoxRetriever, B] extends Validators with Validatab
     super.validateRawStringByRegex(box.id, value, errorCodeBoxId, regex)
   }
 
-  protected def validateStringByRegex(regex: String)(): Set[CtValidation] = {
+  protected def validateStringByRegex(regex: String)()(implicit ev: <:<[B, String]): Set[CtValidation] = {
     super.validateStringByRegex(box.id, box.asInstanceOf[StringIdBox], regex)
   }
 
-  protected def validateCoHoOptionalString()(): Set[CtValidation] = {
+  protected def validateCoHoOptionalString()()(implicit ev: <:<[B, Option[String]]): Set[CtValidation] = {
     super.validateCoHoOptionalString(box.id, box.asInstanceOf[OptionalStringIdBox])
   }
 
-  protected def validateCohoNameField()(): Set[CtValidation] = {
+  protected def validateCohoNameField()()(implicit ev: <:<[B, String]): Set[CtValidation] = {
     super.validateCohoNameField(box.id, box.asInstanceOf[StringIdBox])
   }
 
-  protected def validateCohoOptionalNameField()(): Set[CtValidation] = {
+  protected def validateCohoOptionalNameField()()(implicit ev: <:<[B, Option[String]]): Set[CtValidation] = {
     super.validateCohoOptionalNameField(box.id, box.asInstanceOf[OptionalStringIdBox])
   }
 
@@ -153,12 +150,12 @@ trait SelfValidatableBox[T <: BoxRetriever, B] extends Validators with Validatab
     super.validateCoHoString(box.id, value, errorCodeBoxId)
   }
 
-  protected def validateOptionalStringByLength(min: Int, max: Int)()(implicit ev: <:<[B, String]): Set[CtValidation] = {
+  protected def validateOptionalStringByLength(min: Int, max: Int)()(implicit ev: <:<[B, Option[String]]): Set[CtValidation] = {
     super.validateOptionalStringByLength(box.id, box.asInstanceOf[OptionalStringIdBox], min, max)
   }
 
-  protected def validateStringByLength(boxValue: CtString, min:Int, max:Int)(): Set[CtValidation] = {
-    super.validateStringByLength(box.id, boxValue, min, max)
+  protected def validateStringByLength(min:Int, max:Int)()(implicit ev: <:<[B, String]): Set[CtValidation] = {
+    super.validateStringByLength(box.id, box.asInstanceOf[StringIdBox], min, max)
   }
 
   def validateNotEmptyStringByLength(value: String, min: Int, max: Int)(): Set[CtValidation] = {
@@ -173,7 +170,7 @@ trait SelfValidatableBox[T <: BoxRetriever, B] extends Validators with Validatab
     super.validateStringMaxLength(box.id, value, max)
   }
 
-  def validatePostcode(boxId: String)(): Set[CtValidation] = {
+  def validatePostcode(boxId: String)()(implicit ev: <:<[B, Option[String]]): Set[CtValidation] = {
     super.validatePostcode(box.id, box.asInstanceOf[OptionalStringIdBox])
   }
 

--- a/src/main/scala/uk/gov/hmrc/ct/box/SelfValidatableBox.scala
+++ b/src/main/scala/uk/gov/hmrc/ct/box/SelfValidatableBox.scala
@@ -31,19 +31,19 @@ trait SelfValidatableBox[T <: BoxRetriever, B] extends Validators with Validatab
   def validate(boxRetriever: T): Set[CtValidation]
 
   protected def validateBooleanAsMandatory()()(implicit ev: <:<[B, Option[Boolean]]): Set[CtValidation] = {
-    super.validateBooleanAsMandatory(box.id, box.asInstanceOf[OptionalBooleanIdBox])
+    super.validateBooleanAsMandatory(box.id, box)
   }
 
   protected def validateBooleanAsTrue()()(implicit ev: <:<[B, Option[Boolean]]): Set[CtValidation] = {
-    super.validateBooleanAsTrue(box.id, box.asInstanceOf[OptionalBooleanIdBox])
+    super.validateBooleanAsTrue(box.id, box)
   }
 
   protected def validateIntegerAsMandatory()()(implicit ev: <:<[B, Option[Int]]): Set[CtValidation] = {
-    super.validateIntegerAsMandatory(box.id, box.asInstanceOf[OptionalIntIdBox])
+    super.validateIntegerAsMandatory(box.id, box)
   }
 
   protected def validateStringAsMandatory()()(implicit ev: <:<[B, Option[String]]): Set[CtValidation] = {
-    super.validateStringAsMandatory(box.id, box.asInstanceOf[OptionalStringIdBox])
+    super.validateStringAsMandatory(box.id, box)
   }
 
   protected def validateAsMandatory()(): Set[CtValidation] = {
@@ -51,7 +51,7 @@ trait SelfValidatableBox[T <: BoxRetriever, B] extends Validators with Validatab
   }
 
   protected def validateStringAsMandatoryIfPAYEEQ1False(boxRetriever: RepaymentsBoxRetriever)()(implicit ev: <:<[B, Option[String]]): Set[CtValidation] = {
-    super.validateStringAsMandatoryIfPAYEEQ1False(boxRetriever, box.id, box.asInstanceOf[OptionalStringIdBox])
+    super.validateStringAsMandatoryIfPAYEEQ1False(boxRetriever, box.id, box)
   }
 
   protected def validateAllFilledOrEmptyStrings(allBoxes: Set[CtValue[String]])(): Set[CtValidation] = {
@@ -63,11 +63,11 @@ trait SelfValidatableBox[T <: BoxRetriever, B] extends Validators with Validatab
   }
 
   protected def validateStringAsBlank()()(implicit ev: <:<[B, Option[String]]): Set[CtValidation] = {
-    super.validateStringAsBlank(box.id, box.asInstanceOf[OptionalStringIdBox])
+    super.validateStringAsBlank(box.id, box)
   }
 
   protected def validateDateAsMandatory()()(implicit ev: <:<[B, Option[LocalDate]]): Set[CtValidation] = {
-    super.validateDateAsMandatory(box.id, box.value.asInstanceOf[Option[LocalDate]], box.id): Set[CtValidation]
+    super.validateDateAsMandatory(box.id, box.value, box.id): Set[CtValidation]
   }
 
   protected def validateDateAsMandatory(date: Option[LocalDate], messageId: String)(): Set[CtValidation] = {
@@ -75,19 +75,19 @@ trait SelfValidatableBox[T <: BoxRetriever, B] extends Validators with Validatab
   }
 
   protected def validateDateAsBlank()()(implicit ev: <:<[B, Option[LocalDate]]): Set[CtValidation] = {
-    super.validateDateAsBlank(box.id, box.asInstanceOf[OptionalDateIdBox])
+    super.validateDateAsBlank(box.id, box)
   }
 
   protected def validateDateAsBefore(dateToCompare: LocalDate)()(implicit ev: <:<[B, Option[LocalDate]]): Set[CtValidation] = {
-    super.validateDateAsBefore(box.id, box.asInstanceOf[OptionalDateIdBox], dateToCompare)
+    super.validateDateAsBefore(box.id, box, dateToCompare)
   }
 
   protected def validateDateAsAfter(dateToCompare: LocalDate)()(implicit ev: <:<[B, Option[LocalDate]]): Set[CtValidation] = {
-    super.validateDateAsAfter(box.id, box.asInstanceOf[OptionalDateIdBox], dateToCompare)
+    super.validateDateAsAfter(box.id, box, dateToCompare)
   }
 
   protected def validateDateAsBetweenInclusive(minDate: LocalDate, maxDate: LocalDate)()(implicit ev: <:<[B, Option[LocalDate]]): Set[CtValidation] = {
-    validateDateAsBetweenInclusive(box.value.asInstanceOf[Option[LocalDate]], minDate, maxDate, box.id)
+    validateDateAsBetweenInclusive(box.value, minDate, maxDate, box.id)
   }
 
   protected def validateDateAsBetweenInclusive(date: Option[LocalDate], minDate: LocalDate, maxDate: LocalDate, messageId: String)(): Set[CtValidation] = {
@@ -95,27 +95,27 @@ trait SelfValidatableBox[T <: BoxRetriever, B] extends Validators with Validatab
   }
 
   protected def validateIntegerAsBlank()()(implicit ev: <:<[B, Option[Int]]): Set[CtValidation] = {
-    super.validateIntegerAsBlank(box.id, box.asInstanceOf[OptionalIntIdBox])
+    super.validateIntegerAsBlank(box.id, box)
   }
 
   protected def validateIntegerRange(min: Int = 0, max: Int)()(implicit ev: <:<[B, Option[Int]]): Set[CtValidation] = {
-    super.validateIntegerRange(box.id, box.asInstanceOf[OptionalIntIdBox], min, max)
+    super.validateIntegerRange(box.id, box, min, max)
   }
 
   protected def validateZeroOrPositiveBigDecimal()()(implicit ev: <:<[B, Option[BigDecimal]]): Set[CtValidation] = {
-    super.validateZeroOrPositiveBigDecimal(box.asInstanceOf[OptionalBigDecimalIdBox])
+    super.validateZeroOrPositiveBigDecimal(box)
   }
 
   protected def validateZeroOrPositiveInteger()()(implicit ev: <:<[B, Option[Int]]): Set[CtValidation] = {
-    super.validateZeroOrPositiveInteger(box.asInstanceOf[OptionalIntIdBox])
+    super.validateZeroOrPositiveInteger(box)
   }
 
   protected def validatePositiveBigDecimal()()(implicit ev: <:<[B, Option[BigDecimal]]): Set[CtValidation] = {
-    super.validatePositiveBigDecimal(box.asInstanceOf[OptionalBigDecimalIdBox])
+    super.validatePositiveBigDecimal(box)
   }
 
   protected def validatePositiveInteger()()(implicit ev: <:<[B, Option[Int]]): Set[CtValidation] = {
-    super.validatePositiveInteger(box.asInstanceOf[OptionalIntIdBox])
+    super.validatePositiveInteger(box)
   }
 
   protected def validateOptionalIntegerAsEqualTo(equalToBox: CtBoxIdentifier with CtOptionalInteger)(implicit ev: <:<[B, CtBoxIdentifier with CtOptionalInteger]): Set[CtValidation] = {
@@ -123,7 +123,7 @@ trait SelfValidatableBox[T <: BoxRetriever, B] extends Validators with Validatab
   }
 
   protected def validateOptionalStringByRegex(regex: String)()(implicit ev: <:<[B, Option[String]]): Set[CtValidation] = {
-    super.validateOptionalStringByRegex(box.id, box.asInstanceOf[OptionalStringIdBox], regex)
+    super.validateOptionalStringByRegex(box.id, box, regex)
   }
 
   protected def validateRawStringByRegex(value: String, errorCodeBoxId: String, regex: String)(): Set[CtValidation] = {
@@ -131,19 +131,19 @@ trait SelfValidatableBox[T <: BoxRetriever, B] extends Validators with Validatab
   }
 
   protected def validateStringByRegex(regex: String)()(implicit ev: <:<[B, String]): Set[CtValidation] = {
-    super.validateStringByRegex(box.id, box.asInstanceOf[StringIdBox], regex)
+    super.validateStringByRegex(box.id, box, regex)
   }
 
   protected def validateCoHoOptionalString()()(implicit ev: <:<[B, Option[String]]): Set[CtValidation] = {
-    super.validateCoHoOptionalString(box.id, box.asInstanceOf[OptionalStringIdBox])
+    super.validateCoHoOptionalString(box.id, box)
   }
 
   protected def validateCohoNameField()()(implicit ev: <:<[B, String]): Set[CtValidation] = {
-    super.validateCohoNameField(box.id, box.asInstanceOf[StringIdBox])
+    super.validateCohoNameField(box.id, box)
   }
 
   protected def validateCohoOptionalNameField()()(implicit ev: <:<[B, Option[String]]): Set[CtValidation] = {
-    super.validateCohoOptionalNameField(box.id, box.asInstanceOf[OptionalStringIdBox])
+    super.validateCohoOptionalNameField(box.id, box)
   }
 
   protected def validateCoHoString(value: String, errorCodeBoxId: Option[String])(): Set[CtValidation] = {
@@ -151,11 +151,11 @@ trait SelfValidatableBox[T <: BoxRetriever, B] extends Validators with Validatab
   }
 
   protected def validateOptionalStringByLength(min: Int, max: Int)()(implicit ev: <:<[B, Option[String]]): Set[CtValidation] = {
-    super.validateOptionalStringByLength(box.id, box.asInstanceOf[OptionalStringIdBox], min, max)
+    super.validateOptionalStringByLength(box.id, box, min, max)
   }
 
   protected def validateStringByLength(min:Int, max:Int)()(implicit ev: <:<[B, String]): Set[CtValidation] = {
-    super.validateStringByLength(box.id, box.asInstanceOf[StringIdBox], min, max)
+    super.validateStringByLength(box.id, box, min, max)
   }
 
   def validateNotEmptyStringByLength(value: String, min: Int, max: Int)(): Set[CtValidation] = {
@@ -171,8 +171,15 @@ trait SelfValidatableBox[T <: BoxRetriever, B] extends Validators with Validatab
   }
 
   def validatePostcode(boxId: String)()(implicit ev: <:<[B, Option[String]]): Set[CtValidation] = {
-    super.validatePostcode(box.id, box.asInstanceOf[OptionalStringIdBox])
+    super.validatePostcode(box.id, box)
   }
 
+
+  implicit def box2StringIdBox(box: CtValue[_] with CtBoxIdentifier): StringIdBox = box.asInstanceOf[StringIdBox]
+  implicit def box2OptionalIntIdBox(box: CtValue[_] with CtBoxIdentifier): OptionalIntIdBox = box.asInstanceOf[OptionalIntIdBox]
+  implicit def box2OptionalBooleanIdBox(box: CtValue[_] with CtBoxIdentifier): OptionalBooleanIdBox = box.asInstanceOf[OptionalBooleanIdBox]
+  implicit def box2OptionalStringIdBox(box: CtValue[_] with CtBoxIdentifier): OptionalStringIdBox = box.asInstanceOf[OptionalStringIdBox]
+  implicit def box2OptionalDateIdBox(box: CtValue[_] with CtBoxIdentifier): OptionalDateIdBox = box.asInstanceOf[OptionalDateIdBox]
+  implicit def box2OptionalBigDecimalIdBox(box: CtValue[_] with CtBoxIdentifier): OptionalBigDecimalIdBox = box.asInstanceOf[OptionalBigDecimalIdBox]
 }
 

--- a/src/main/scala/uk/gov/hmrc/ct/box/ValidatableBox.scala
+++ b/src/main/scala/uk/gov/hmrc/ct/box/ValidatableBox.scala
@@ -30,6 +30,7 @@ trait ValidatableBox[T <: BoxRetriever] extends Validators {
   type OptionalBooleanIdBox = CtValue[Option[Boolean]] with CtBoxIdentifier
   type OptionalIntIdBox = CtValue[Option[Int]] with CtBoxIdentifier
   type OptionalStringIdBox = CtValue[Option[String]] with CtBoxIdentifier
+  type StringIdBox = CtValue[String] with CtBoxIdentifier
   type OptionalDateIdBox = CtValue[Option[LocalDate]] with CtBoxIdentifier
   type OptionalBigDecimalIdBox = CtValue[Option[BigDecimal]] with CtBoxIdentifier
 
@@ -227,13 +228,13 @@ trait ValidatableBox[T <: BoxRetriever] extends Validators {
     }
   }
 
-  protected def validateStringByRegex(boxId: String, box: CtString, regex: String)(): Set[CtValidation] = {
+  protected def validateStringByRegex(boxId: String, box: StringIdBox, regex: String)(): Set[CtValidation] = {
     passIf (box.value.isEmpty || box.value.matches(regex)) {
       Set(CtValidation(Some(boxId), s"error.$boxId.regexFailure"))
     }
   }
 
-  protected def validateCoHoOptionalString(boxId: String, box: CtOptionalString)(): Set[CtValidation] = {
+  protected def validateCoHoOptionalString(boxId: String, box: OptionalStringIdBox)(): Set[CtValidation] = {
     box.value match {
       case Some(x) if x.nonEmpty => {
         validateCoHoString(boxId, x)
@@ -242,11 +243,11 @@ trait ValidatableBox[T <: BoxRetriever] extends Validators {
     }
   }
 
-  protected def validateCohoNameField(boxId: String, box: CtString)(): Set[CtValidation] = {
+  protected def validateCohoNameField(boxId: String, box: StringIdBox)(): Set[CtValidation] = {
     validateStringByRegex(boxId, box, ValidCoHoNamesCharacters)
   }
 
-  protected def validateCohoOptionalNameField(boxId: String, box: CtOptionalString)(): Set[CtValidation] = {
+  protected def validateCohoOptionalNameField(boxId: String, box: OptionalStringIdBox)(): Set[CtValidation] = {
     validateOptionalStringByRegex(boxId, box, ValidCoHoNamesCharacters)
   }
 

--- a/src/main/scala/uk/gov/hmrc/ct/box/ValidatableBox.scala
+++ b/src/main/scala/uk/gov/hmrc/ct/box/ValidatableBox.scala
@@ -36,7 +36,7 @@ trait ValidatableBox[T <: BoxRetriever] extends Validators {
 
 
   // Taken from PostCodeType on http://www.hmrc.gov.uk/schemas/core-v2-0.xsd
-  private val postCodeRegex = """(GIR 0AA)|((([A-Z][0-9][0-9]?)|(([A-Z][A-HJ-Y][0-9][0-9]?)|(([A-Z][0-9][A-Z])|([A-Z][A-HJ-Y][0-9]?[A-Z])))) [0-9][A-Z]{2})"""
+  protected val postCodeRegex = """(GIR 0AA)|((([A-Z][0-9][0-9]?)|(([A-Z][A-HJ-Y][0-9][0-9]?)|(([A-Z][0-9][A-Z])|([A-Z][A-HJ-Y][0-9]?[A-Z])))) [0-9][A-Z]{2})"""
 
   def validate(boxRetriever: T): Set[CtValidation]
 
@@ -274,7 +274,7 @@ trait ValidatableBox[T <: BoxRetriever] extends Validators {
     }
   }
 
-  protected def validateStringByLength(boxId: String, box: CtString, min:Int, max:Int)(): Set[CtValidation] = {
+  protected def validateStringByLength(boxId: String, box: StringIdBox, min:Int, max:Int)(): Set[CtValidation] = {
      validateNotEmptyStringByLength(boxId, box.value, min, max)
   }
 

--- a/src/main/scala/uk/gov/hmrc/ct/box/ValidatableBox.scala
+++ b/src/main/scala/uk/gov/hmrc/ct/box/ValidatableBox.scala
@@ -27,26 +27,34 @@ import ValidatableBox._
 
 trait ValidatableBox[T <: BoxRetriever] extends Validators {
 
+  type OptionalBooleanIdBox = CtValue[Option[Boolean]] with CtBoxIdentifier
+  type OptionalIntIdBox = CtValue[Option[Int]] with CtBoxIdentifier
+  type OptionalStringIdBox = CtValue[Option[String]] with CtBoxIdentifier
+  type OptionalDateIdBox = CtValue[Option[LocalDate]] with CtBoxIdentifier
+  type OptionalBigDecimalIdBox = CtValue[Option[BigDecimal]] with CtBoxIdentifier
+
+
   // Taken from PostCodeType on http://www.hmrc.gov.uk/schemas/core-v2-0.xsd
   private val postCodeRegex = """(GIR 0AA)|((([A-Z][0-9][0-9]?)|(([A-Z][A-HJ-Y][0-9][0-9]?)|(([A-Z][0-9][A-Z])|([A-Z][A-HJ-Y][0-9]?[A-Z])))) [0-9][A-Z]{2})"""
 
   def validate(boxRetriever: T): Set[CtValidation]
 
-  protected def validateBooleanAsMandatory(boxId: String, box: CtOptionalBoolean)(): Set[CtValidation] = {
+
+  protected def validateBooleanAsMandatory(boxId: String, box: OptionalBooleanIdBox)(): Set[CtValidation] = {
     box.value match {
       case None => Set(CtValidation(Some(boxId), s"error.$boxId.required"))
       case _ => Set()
     }
   }
 
-  protected def validateIntegerAsMandatory(boxId: String, box: CtOptionalInteger)(): Set[CtValidation] = {
+  protected def validateIntegerAsMandatory(boxId: String, box: OptionalIntIdBox)(): Set[CtValidation] = {
     box.value match {
       case None => Set(CtValidation(Some(boxId), s"error.$boxId.required"))
       case _ => Set()
     }
   }
 
-  protected def validateStringAsMandatory(boxId: String, box: CtOptionalString)(): Set[CtValidation] = {
+  protected def validateStringAsMandatory(boxId: String, box: OptionalStringIdBox)(): Set[CtValidation] = {
     box.value match {
       case None => Set(CtValidation(Some(boxId), s"error.$boxId.required"))
       case Some(x) if x.isEmpty => Set(CtValidation(Some(boxId), s"error.$boxId.required"))
@@ -61,14 +69,14 @@ trait ValidatableBox[T <: BoxRetriever] extends Validators {
     }
   }
 
-  protected def validateStringAsMandatoryIfPAYEEQ1False(boxRetriever: RepaymentsBoxRetriever, boxId: String, box: CtOptionalString)(): Set[CtValidation] = {
+  protected def validateStringAsMandatoryIfPAYEEQ1False(boxRetriever: RepaymentsBoxRetriever, boxId: String, box: OptionalStringIdBox)(): Set[CtValidation] = {
     val payeeq1 = boxRetriever.payeeQ1()
     if (!payeeq1.value.getOrElse(true)) {
       validateStringAsMandatory(boxId, box)
     } else Set()
   }
 
-  protected def validateAllFilledOrEmptyStrings(boxId: String, allBoxes: Set[CtString])(): Set[CtValidation] = {
+  protected def validateAllFilledOrEmptyStrings(boxId: String, allBoxes: Set[CtValue[String]])(): Set[CtValidation] = {
     val allEmpty = allBoxes.count(_.value.isEmpty) == allBoxes.size
     val allNonEmpty = allBoxes.count(_.value.nonEmpty) == allBoxes.size
 
@@ -78,7 +86,7 @@ trait ValidatableBox[T <: BoxRetriever] extends Validators {
   }
 
   protected def validateAllFilledOrEmptyStringsForBankDetails(boxRetriever: RepaymentsBoxRetriever, boxId: String)(): Set[CtValidation] = {
-    val bankDetailsBoxGroup:Set[CtString] = Set(
+    val bankDetailsBoxGroup:Set[CtValue[String]] = Set(
       boxRetriever.b920(),
       boxRetriever.b925(),
       boxRetriever.b930(),
@@ -87,7 +95,7 @@ trait ValidatableBox[T <: BoxRetriever] extends Validators {
     validateAllFilledOrEmptyStrings(boxId, bankDetailsBoxGroup)
   }
 
-  protected def validateStringAsBlank(boxId: String, box: CtOptionalString)(): Set[CtValidation] = {
+  protected def validateStringAsBlank(boxId: String, box: OptionalStringIdBox)(): Set[CtValidation] = {
     box.value match {
       case None => Set()
       case Some(x) if x.isEmpty => Set()
@@ -95,7 +103,7 @@ trait ValidatableBox[T <: BoxRetriever] extends Validators {
     }
   }
 
-  protected def validateDateAsMandatory(boxId: String, box: CtOptionalDate)(): Set[CtValidation] = {
+  protected def validateDateAsMandatory(boxId: String, box: OptionalDateIdBox)(): Set[CtValidation] = {
     validateDateAsMandatory(boxId, box.value, boxId): Set[CtValidation]
   }
 
@@ -106,14 +114,14 @@ trait ValidatableBox[T <: BoxRetriever] extends Validators {
     }
   }
 
-  protected def validateDateAsBlank(boxId: String, box: CtOptionalDate)(): Set[CtValidation] = {
+  protected def validateDateAsBlank(boxId: String, box: OptionalDateIdBox)(): Set[CtValidation] = {
     box.value match {
       case None => Set()
       case _ => Set(CtValidation(Some(boxId), s"error.$boxId.nonBlankValue"))
     }
   }
 
-  protected def validateDateAsBefore(boxId: String, box: CtOptionalDate, dateToCompare: LocalDate)(): Set[CtValidation] = {
+  protected def validateDateAsBefore(boxId: String, box: OptionalDateIdBox, dateToCompare: LocalDate)(): Set[CtValidation] = {
     box.value match {
       case None => Set()
       case Some(date) if date < dateToCompare => Set()
@@ -121,7 +129,7 @@ trait ValidatableBox[T <: BoxRetriever] extends Validators {
     }
   }
 
-  protected def validateDateAsAfter(boxId: String, box: CtOptionalDate, dateToCompare: LocalDate)(): Set[CtValidation] = {
+  protected def validateDateAsAfter(boxId: String, box: OptionalDateIdBox, dateToCompare: LocalDate)(): Set[CtValidation] = {
     box.value match {
       case None => Set()
       case Some(date) if date > dateToCompare => Set()
@@ -129,7 +137,7 @@ trait ValidatableBox[T <: BoxRetriever] extends Validators {
     }
   }
 
-  protected def validateDateAsBetweenInclusive(boxId: String, box: CtOptionalDate, minDate: LocalDate, maxDate: LocalDate)(): Set[CtValidation] = {
+  protected def validateDateAsBetweenInclusive(boxId: String, box: OptionalDateIdBox, minDate: LocalDate, maxDate: LocalDate)(): Set[CtValidation] = {
     validateDateAsBetweenInclusive(boxId, box.value, minDate, maxDate, boxId)
   }
 
@@ -142,14 +150,14 @@ trait ValidatableBox[T <: BoxRetriever] extends Validators {
     }
   }
 
-  protected def validateIntegerAsBlank(boxId: String, box: CtOptionalInteger)(): Set[CtValidation] = {
+  protected def validateIntegerAsBlank(boxId: String, box: OptionalIntIdBox)(): Set[CtValidation] = {
     box.value match {
       case None => Set()
       case _ => Set(CtValidation(Some(boxId), s"error.$boxId.nonBlankValue"))
     }
   }
 
-  protected def validateIntegerRange(boxId: String, box: CtOptionalInteger, min: Int = 0, max: Int)(): Set[CtValidation] = {
+  protected def validateIntegerRange(boxId: String, box: OptionalIntIdBox, min: Int, max: Int)(): Set[CtValidation] = {
     box.value match {
       case Some(x) => {
         passIf (min <= x && x <= max) {
@@ -160,28 +168,28 @@ trait ValidatableBox[T <: BoxRetriever] extends Validators {
     }
   }
 
-  protected def validateZeroOrPositiveBigDecimal(box: CtOptionalBigDecimal with CtBoxIdentifier)(): Set[CtValidation] = {
+  protected def validateZeroOrPositiveBigDecimal(box: OptionalBigDecimalIdBox)(): Set[CtValidation] = {
     box.value match {
       case Some(x) if x < BigDecimal(0) => Set(CtValidation(Some(box.id), s"error.${box.id}.mustBeZeroOrPositive"))
       case _ => Set()
     }
   }
 
-  protected def validateZeroOrPositiveInteger(box: CtOptionalInteger with CtBoxIdentifier)(): Set[CtValidation] = {
+  protected def validateZeroOrPositiveInteger(box: OptionalIntIdBox)(): Set[CtValidation] = {
     box.value match {
       case Some(x) if x < 0 => Set(CtValidation(Some(box.id), s"error.${box.id}.mustBeZeroOrPositive"))
       case _ => Set()
     }
   }
 
-  protected def validatePositiveBigDecimal(box: CtOptionalBigDecimal with CtBoxIdentifier)(): Set[CtValidation] = {
+  protected def validatePositiveBigDecimal(box: OptionalBigDecimalIdBox)(): Set[CtValidation] = {
     box.value match {
       case Some(x) if x <= 0 => Set(CtValidation(Some(box.id), s"error.${box.id}.mustBePositive"))
       case _ => Set()
     }
   }
 
-  protected def validatePositiveInteger(box: CtOptionalInteger with CtBoxIdentifier)(): Set[CtValidation] = {
+  protected def validatePositiveInteger(box: OptionalIntIdBox)(): Set[CtValidation] = {
     box.value match {
       case Some(x) if x <= 0 => Set(CtValidation(Some(box.id), s"error.${box.id}.mustBePositive"))
       case _ => Set()
@@ -195,7 +203,7 @@ trait ValidatableBox[T <: BoxRetriever] extends Validators {
       Set.empty
   }
 
-  protected def validateOptionalStringByRegex(boxId: String, box: CtOptionalString, regex: String)(): Set[CtValidation] = {
+  protected def validateOptionalStringByRegex(boxId: String, box: OptionalStringIdBox, regex: String)(): Set[CtValidation] = {
     box.value match {
       case Some(x) if x.nonEmpty => {
         passIf (x.matches(regex)) {
@@ -206,7 +214,7 @@ trait ValidatableBox[T <: BoxRetriever] extends Validators {
     }
   }
 
-  protected def validateCoHoOptionalTextField(boxId: String, box: CtOptionalString)(): Set[CtValidation] = {
+  protected def validateCoHoOptionalTextField(boxId: String, box: OptionalStringIdBox)(): Set[CtValidation] = {
 
     def getIllegalCharacters(x: String): String = {
       val p = Pattern.compile(ValidCoHoCharacters)
@@ -238,7 +246,7 @@ trait ValidatableBox[T <: BoxRetriever] extends Validators {
     }
   }
 
-  protected def validateOptionalStringByLength(boxId: String, box: CtOptionalString, min: Int, max: Int)(): Set[CtValidation] = {
+  protected def validateOptionalStringByLength(boxId: String, box: OptionalStringIdBox, min: Int, max: Int)(): Set[CtValidation] = {
     box.value match {
       case Some(x) => validateNotEmptyStringByLength(boxId, x, min, max)
       case _ => Set()
@@ -268,18 +276,18 @@ trait ValidatableBox[T <: BoxRetriever] extends Validators {
     }
   }
 
-  def validatePostcode(boxId: String, box: CtOptionalString)(): Set[CtValidation] = {
+  def validatePostcode(boxId: String, box: OptionalStringIdBox)(): Set[CtValidation] = {
     validatePostcodeLength(boxId, box) ++ validatePostcodeRegex(boxId, box)
   }
 
-  private def validatePostcodeLength(boxId: String, box: CtOptionalString): Set[CtValidation] = {
+  private def validatePostcodeLength(boxId: String, box: OptionalStringIdBox): Set[CtValidation] = {
     box.value match {
       case Some(x) if x.nonEmpty && x.size < 6 || x.size > 8 => Set(CtValidation(Some(boxId), s"error.$boxId.invalidPostcode"))
       case _ => Set()
     }
   }
 
-  private def validatePostcodeRegex(boxId: String, box: CtOptionalString): Set[CtValidation] = {
+  private def validatePostcodeRegex(boxId: String, box: OptionalStringIdBox): Set[CtValidation] = {
     validateOptionalStringByRegex(boxId, box, postCodeRegex) match {
       case x if x.isEmpty => Set()
       case _ => Set(CtValidation(Some(boxId), s"error.$boxId.invalidPostcode"))

--- a/src/main/scala/uk/gov/hmrc/ct/computations/Validators/AllowancesQuestionsValidation.scala
+++ b/src/main/scala/uk/gov/hmrc/ct/computations/Validators/AllowancesQuestionsValidation.scala
@@ -16,13 +16,13 @@
 
 package uk.gov.hmrc.ct.computations.Validators
 
-import uk.gov.hmrc.ct.box.{CtOptionalBoolean, CtValidation, ValidatableBox}
+import uk.gov.hmrc.ct.box.{CtBoxIdentifier, CtOptionalBoolean, CtValidation, ValidatableBox}
 import uk.gov.hmrc.ct.computations.CPQ7
 import uk.gov.hmrc.ct.computations.retriever.ComputationsBoxRetriever
 
 trait AllowancesQuestionsValidation {
 
-  self: CtOptionalBoolean with ValidatableBox[ComputationsBoxRetriever] =>
+  self: CtOptionalBoolean with ValidatableBox[ComputationsBoxRetriever] with CtBoxIdentifier =>
 
   def validateAgainstCPQ7(boxRetriever: ComputationsBoxRetriever, boxId: String, value: Option[Boolean]): Set[CtValidation] = {
     (boxRetriever.cpQ7(), value) match {

--- a/src/main/scala/uk/gov/hmrc/ct/ct600e/validations/ValidateDeclarationNameOrStatus.scala
+++ b/src/main/scala/uk/gov/hmrc/ct/ct600e/validations/ValidateDeclarationNameOrStatus.scala
@@ -17,11 +17,12 @@
 package uk.gov.hmrc.ct.ct600e.validations
 
 import uk.gov.hmrc.ct.box.retriever.BoxRetriever
-import uk.gov.hmrc.ct.box.{CtOptionalString, CtValidation, ValidatableBox}
+import uk.gov.hmrc.ct.box.{CtBoxIdentifier, CtOptionalString, CtValidation, ValidatableBox}
 import uk.gov.hmrc.ct.box.ValidatableBox._
 
 trait ValidateDeclarationNameOrStatus[T <: BoxRetriever] extends ValidatableBox[T] {
-  def validateDeclarationNameOrStatus(boxId: String, box: CtOptionalString): Set[CtValidation] = {
+
+  def validateDeclarationNameOrStatus(boxId: String, box: CtOptionalString with CtBoxIdentifier): Set[CtValidation] = {
     validateStringAsMandatory(boxId, box) ++ validateOptionalStringByLength(boxId, box, 2, 56) ++ validateOptionalStringByRegex(boxId, box, ValidNonForeignLessRestrictiveCharacters)
   }
 }


### PR DESCRIPTION
Worked on this during my spare time. 

The goal of this change is to simplify validation. 
Mixing in the SelfValidatableBox instead of ValidatableBox, we can avoid passing the boxId and box itself to the validation methods.
