### PR TITLE
CATO-4448: Make note optional for dormant accounts

### DIFF
--- a/src/main/scala/uk/gov/hmrc/ct/accounts/frs102/boxes/AC187.scala
+++ b/src/main/scala/uk/gov/hmrc/ct/accounts/frs102/boxes/AC187.scala
@@ -14,18 +14,13 @@
  * limitations under the License.
  */
 
-package uk.gov.hmrc.ct.accounts.frs102.calculations
+package uk.gov.hmrc.ct.accounts.frs102.boxes
 
-import uk.gov.hmrc.ct.accounts.frs102.boxes._
+import uk.gov.hmrc.ct.box._
 
-trait RevaluationReserveCalculator {
+case class AC187(value: Option[Boolean]) extends CtBoxIdentifier(name = "Revaluation reserve note included") with CtOptionalBoolean with Input
 
-  def calculateAC190(ac76: AC76, ac77: AC77, ac189: AC189): AC190 = {
-    (ac76.value, ac77.value, ac189.value) match {
-      case (Some(_), None, None) =>  AC190(Some(0))
-      case (_, None, None) => AC190(None)
-      case _ => AC190(Some(ac77.orZero + ac189.orZero))
-    }
-  }
+object AC187 {
 
+  def apply(value: Boolean): AC187 = AC187(Some(value))
 }

--- a/src/main/scala/uk/gov/hmrc/ct/accounts/frs102/boxes/AC189.scala
+++ b/src/main/scala/uk/gov/hmrc/ct/accounts/frs102/boxes/AC189.scala
@@ -22,6 +22,7 @@ import uk.gov.hmrc.ct.box._
 import uk.gov.hmrc.ct.box.retriever.BoxRetriever._
 
 case class AC189(value: Option[Int]) extends CtBoxIdentifier(name = "Surplus or deficit after revaluation") with CtOptionalInteger
+                                                                                                              with CtTypeConverters
                                                                                                               with Input
                                                                                                               with ValidatableBox[Frs102AccountsBoxRetriever with Frs10xDormancyBoxRetriever]
                                                                                                               with Validators {
@@ -32,7 +33,7 @@ case class AC189(value: Option[Int]) extends CtBoxIdentifier(name = "Surplus or 
     val dormant = boxRetriever.acq8999().orFalse
 
     collectErrors (
-      failIf(hasReserve && !dormant)(validateIntegerAsMandatory("AC189", this)),
+      failIf(hasReserve && (!dormant || boxRetriever.ac187()))(validateIntegerAsMandatory("AC189", this)),
       failIf(!hasReserve)(validateNoteCannotExist(boxRetriever)),
       validateMoney(value)
     )

--- a/src/main/scala/uk/gov/hmrc/ct/accounts/frs102/formats/package.scala
+++ b/src/main/scala/uk/gov/hmrc/ct/accounts/frs102/formats/package.scala
@@ -225,6 +225,7 @@ package object formats {
   implicit val ac133CFormat = new OptionalIntegerFormat[AC133C](AC133C.apply)
   implicit val ac133DFormat = new OptionalIntegerFormat[AC133D](AC133D.apply)
   implicit val ac133EFormat = new OptionalIntegerFormat[AC133E](AC133E.apply)
+  implicit val ac187Format = new OptionalBooleanFormat[AC187](AC187.apply)
   implicit val ac188Format = new OptionalIntegerFormat[AC188](AC188.apply)
   implicit val ac5133Format = new OptionalStringFormat[AC5133](AC5133.apply)
 

--- a/src/main/scala/uk/gov/hmrc/ct/accounts/frs102/retriever/Frs102AccountsBoxRetriever.scala
+++ b/src/main/scala/uk/gov/hmrc/ct/accounts/frs102/retriever/Frs102AccountsBoxRetriever.scala
@@ -218,6 +218,8 @@ trait Frs102AccountsBoxRetriever extends Frs10xAccountsBoxRetriever {
 
   def ac5133(): AC5133
 
+  def ac187(): AC187
+
   def ac188(): AC188 = AC188(ac77())
 
   def ac189(): AC189

--- a/src/main/scala/uk/gov/hmrc/ct/box/Types.scala
+++ b/src/main/scala/uk/gov/hmrc/ct/box/Types.scala
@@ -20,6 +20,7 @@ import org.joda.time.LocalDate
 
 trait CtTypeConverters {
   implicit def convert(catoBoolean: CtBoolean) : Boolean = catoBoolean.value
+  implicit def convert(catoBoolean: CtOptionalBoolean) : Boolean = catoBoolean.value.getOrElse(false)
   implicit def convert(catoInt: CtInteger) : Int = catoInt.value
   implicit def convert(catoInt: CtOptionalInteger) : Int = catoInt.value.getOrElse(0)
   implicit def convert(catoOptionalBigDecimal: CtOptionalBigDecimal) : Option[BigDecimal] = catoOptionalBigDecimal.value

--- a/src/test/scala/uk/gov/hmrc/ct/accounts/frs102/boxes/AC189Spec.scala
+++ b/src/test/scala/uk/gov/hmrc/ct/accounts/frs102/boxes/AC189Spec.scala
@@ -34,6 +34,7 @@ class AC189Spec extends WordSpec
   override def setUpMocks(): Unit = {
     when(boxRetriever.acq8999()).thenReturn(ACQ8999(None))
     when(boxRetriever.ac76()).thenReturn(AC76(Some(100)))
+    when(boxRetriever.ac187()).thenReturn(AC187(Some(true)))
     when(boxRetriever.ac189()).thenReturn(AC189(Some(10)))
     when(boxRetriever.ac190()).thenReturn(AC190(Some(10)))
     when(boxRetriever.ac5076C()).thenReturn(AC5076C(Some("Test content")))
@@ -47,10 +48,25 @@ class AC189Spec extends WordSpec
       AC189(None).validate(boxRetriever) shouldBe Set(CtValidation(Some("AC189"), "error.AC189.required"))
     }
 
-    "pass validation when AC76 isn't empty and this box is empty for dormant filing" in {
+    "pass validation when the company is dormant and AC187 is empty and this is empty" in {
       when(boxRetriever.acq8999()).thenReturn(ACQ8999(Some(true)))
+      when(boxRetriever.ac187()).thenReturn(AC187(None))
       when(boxRetriever.ac76()).thenReturn(AC76(Some(10)))
-      AC189(None).validate(boxRetriever) shouldBe Set.empty
+      AC189(None).validate(boxRetriever) shouldBe empty
+    }
+
+    "pass validation when the company is dormant and AC187 is false and this is empty" in {
+      when(boxRetriever.acq8999()).thenReturn(ACQ8999(Some(true)))
+      when(boxRetriever.ac187()).thenReturn(AC187(Some(false)))
+      when(boxRetriever.ac76()).thenReturn(AC76(Some(10)))
+      AC189(None).validate(boxRetriever) shouldBe empty
+    }
+
+    "fail validation when the company is dormant and AC187 is true and this is empty" in {
+      when(boxRetriever.acq8999()).thenReturn(ACQ8999(Some(true)))
+      when(boxRetriever.ac187()).thenReturn(AC187(Some(true)))
+      when(boxRetriever.ac76()).thenReturn(AC76(Some(10)))
+      AC189(None).validate(boxRetriever) shouldBe Set(CtValidation(Some("AC189"), "error.AC189.required"))
     }
 
     "throw global error when note cannot be entered" in {


### PR DESCRIPTION
To get the required behaviour we need a new box which
indicates that the filing has a revaluation reserve
note. When this is true, AC189 needs to be present and
AC190 needs to equal AC76. If it is not then AC190 is
None and valid and AC189 should be optional.