### PR TITLE
CATO-4761: Removes obsolete error trait from AP1 and AP3

### DIFF
--- a/src/main/scala/uk/gov/hmrc/ct/box/Types.scala
+++ b/src/main/scala/uk/gov/hmrc/ct/box/Types.scala
@@ -251,17 +251,6 @@ trait MustBeZeroOrPositive {
   require(value >= 0, "This box must cannot have a negative value.")
 }
 
-trait MustBeNoneOrZeroOrPositive {
-
-  self: CtOptionalInteger =>
-
-  require(value match {
-    case Some(v) if v >= 0 => true
-    case None => true
-    case _ => false
-  })
-}
-
 trait MustBeNoneOrZeroOrPositiveDecimal {
 
   self: CtOptionalBigDecimal =>

--- a/src/main/scala/uk/gov/hmrc/ct/computations/AP1.scala
+++ b/src/main/scala/uk/gov/hmrc/ct/computations/AP1.scala
@@ -18,7 +18,7 @@ package uk.gov.hmrc.ct.computations
 
 import uk.gov.hmrc.ct.box._
 
-case class AP1(inputValue: Option[Int], defaultValue: Option[Int]) extends CtBoxIdentifier(name = "Turnover apportioned before accounting period") with CtOptionalInteger with MustBeNoneOrZeroOrPositive with InputWithDefault[Int]
+case class AP1(inputValue: Option[Int], defaultValue: Option[Int]) extends CtBoxIdentifier(name = "Turnover apportioned before accounting period") with CtOptionalInteger with InputWithDefault[Int]
 
 object AP1 {
 

--- a/src/main/scala/uk/gov/hmrc/ct/computations/AP3.scala
+++ b/src/main/scala/uk/gov/hmrc/ct/computations/AP3.scala
@@ -18,7 +18,7 @@ package uk.gov.hmrc.ct.computations
 
 import uk.gov.hmrc.ct.box._
 
-case class AP3(inputValue: Option[Int], defaultValue: Option[Int]) extends CtBoxIdentifier(name = "Turnover apportioned after accounting period") with CtOptionalInteger with MustBeNoneOrZeroOrPositive with InputWithDefault[Int]
+case class AP3(inputValue: Option[Int], defaultValue: Option[Int]) extends CtBoxIdentifier(name = "Turnover apportioned after accounting period") with CtOptionalInteger with InputWithDefault[Int]
 
 object AP3 {
 


### PR DESCRIPTION
AP1 and AP3 were extended with an error trait which threw on failure.
This is both inconsistent with the current ctValidation error behaviour
and causes the app to crash instead of prompting the user to make a
change. It is also an unnecessary check given the validation on AC12.