### PR TITLE
CATO-3840 Validation of CP510 for de-block income from property

### DIFF
--- a/src/main/scala/uk/gov/hmrc/ct/computations/CP510.scala
+++ b/src/main/scala/uk/gov/hmrc/ct/computations/CP510.scala
@@ -24,11 +24,11 @@ case class CP510(value: Option[Int]) extends CtBoxIdentifier(name = "Unallowable
   override def validate(boxRetriever: ComputationsBoxRetriever): Set[CtValidation] = {
     collectErrors(
       validateZeroOrPositiveInteger(this),
-      unAllowableError(boxRetriever)
+      unAllowableExpensesError(boxRetriever)
     )
   }
 
-  private def unAllowableError(boxRetriever: ComputationsBoxRetriever) = {
+  private def unAllowableExpensesError(boxRetriever: ComputationsBoxRetriever) = {
     failIf(hasValue && value.get > boxRetriever.cp508().value) {
       Set(CtValidation(None, "block.incomeFromProperty.unAllowable.error"))
     }

--- a/src/main/scala/uk/gov/hmrc/ct/computations/CP510.scala
+++ b/src/main/scala/uk/gov/hmrc/ct/computations/CP510.scala
@@ -16,6 +16,26 @@
 
 package uk.gov.hmrc.ct.computations
 
-import uk.gov.hmrc.ct.box.{CtBoxIdentifier, CtOptionalInteger, Input}
+import uk.gov.hmrc.ct.box._
+import uk.gov.hmrc.ct.computations.retriever.ComputationsBoxRetriever
 
-case class CP510(value: Option[Int]) extends CtBoxIdentifier(name = "Unallowable expenses") with CtOptionalInteger with Input
+case class CP510(value: Option[Int]) extends CtBoxIdentifier(name = "Unallowable expenses") with CtOptionalInteger
+  with Input with ValidatableBox[ComputationsBoxRetriever] {
+  override def validate(boxRetriever: ComputationsBoxRetriever): Set[CtValidation] = {
+    collectErrors(
+      validateZeroOrPositiveInteger(this),
+      unAllowableError(boxRetriever)
+    )
+  }
+
+  private def unAllowableError(boxRetriever: ComputationsBoxRetriever) = {
+    failIf(hasValue && value.get > boxRetriever.cp508().value) {
+      Set(CtValidation(None, "block.incomeFromProperty.unAllowable.error"))
+    }
+  }
+
+}
+
+object CP510 {
+  def apply(value: Int): CP510 = CP510(Some(value))
+}

--- a/src/test/scala/uk/gov/hmrc/ct/computations/CP510Spec.scala
+++ b/src/test/scala/uk/gov/hmrc/ct/computations/CP510Spec.scala
@@ -45,6 +45,10 @@ class CP510Spec extends WordSpec with Matchers with MockitoSugar {
         when(boxRetriever.cp508()).thenReturn(CP508(CP503(Some(5))))
         CP510(Some(10)).validate(boxRetriever) shouldBe Set(CtValidation(None, "block.incomeFromProperty.unAllowable.error"))
       }
+      "fail validation when greater than CP508 (because CP503 is none, and replaced by zero CP508 in implementation)" in {
+        when(boxRetriever.cp508()).thenReturn(CP508(CP503(None)))
+        CP510(Some(5)).validate(boxRetriever) shouldBe Set(CtValidation(None, "block.incomeFromProperty.unAllowable.error"))
+      }
       "pass validation when smaller than CP508" in {
         when(boxRetriever.cp508()).thenReturn(CP508(CP503(Some(10))))
         CP510(Some(5)).validate(boxRetriever) shouldBe empty

--- a/src/test/scala/uk/gov/hmrc/ct/computations/CP510Spec.scala
+++ b/src/test/scala/uk/gov/hmrc/ct/computations/CP510Spec.scala
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2017 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.ct.computations
+
+import org.mockito.Mockito.when
+import org.scalatest.mock.MockitoSugar
+import org.scalatest.{Matchers, WordSpec}
+import uk.gov.hmrc.ct.box.CtValidation
+import uk.gov.hmrc.ct.computations.retriever.ComputationsBoxRetriever
+
+class CP510Spec extends WordSpec with Matchers with MockitoSugar {
+
+  "CP510" should {
+    val boxRetriever: ComputationsBoxRetriever = mock[ComputationsBoxRetriever]
+    "when empty" when {
+      "pass validation when CP508 is empty" in {
+        when(boxRetriever.cp508()).thenReturn(CP508(CP503(None)))
+        CP510(None).validate(boxRetriever) shouldBe empty
+      }
+      "pass validation when CP508 is not empty" in {
+        when(boxRetriever.cp508()).thenReturn(CP508(10))
+        CP510(None).validate(boxRetriever) shouldBe empty
+      }
+    }
+    "when non empty" when {
+      "fail validation when smaller than zero" in {
+        when(boxRetriever.cp508()).thenReturn(CP508(CP503(Some(5))))
+        CP510(Some(-5)).validate(boxRetriever) shouldBe Set(CtValidation(Some("CP510"), s"error.CP510.mustBeZeroOrPositive"))
+      }
+      "fail validation when greater than CP508" in {
+        when(boxRetriever.cp508()).thenReturn(CP508(CP503(Some(5))))
+        CP510(Some(10)).validate(boxRetriever) shouldBe Set(CtValidation(None, "block.incomeFromProperty.unAllowable.error"))
+      }
+      "pass validation when smaller than CP508" in {
+        when(boxRetriever.cp508()).thenReturn(CP508(CP503(Some(10))))
+        CP510(Some(5)).validate(boxRetriever) shouldBe empty
+      }
+      "pass validation when equal to CP508" in {
+        when(boxRetriever.cp508()).thenReturn(CP508(CP503(Some(10))))
+        CP510(Some(10)).validate(boxRetriever) shouldBe empty
+      }
+    }
+  }
+}


### PR DESCRIPTION
This change is required for de-block computations in CATO 