### PR TITLE
CATO-4894  Modified CP33 to allow positive and negative numbers inclu…

### DIFF
--- a/src/main/scala/uk/gov/hmrc/ct/box/Types.scala
+++ b/src/main/scala/uk/gov/hmrc/ct/box/Types.scala
@@ -244,6 +244,14 @@ trait CtOptionalDate extends OptionalCtValue[LocalDate] {
 
 }
 
+trait IsNegativeOrPositive {
+
+  self: CtInteger =>
+
+  require(value >= 0 || value <= 0, "This box must be either positive or negative")
+}
+
+
 trait MustBeZeroOrPositive {
 
   self: CtInteger =>

--- a/src/main/scala/uk/gov/hmrc/ct/box/ValidatableBox.scala
+++ b/src/main/scala/uk/gov/hmrc/ct/box/ValidatableBox.scala
@@ -176,6 +176,12 @@ trait ValidatableBox[T <: BoxRetriever] extends Validators {
     }
   }
 
+  protected  def isPositiveOrNegative(box: OptionalIntIdBox)(): Set[CtValidation] = {
+    box.value match {
+      case Some(x) => Set()
+    }
+  }
+
   protected def validateZeroOrPositiveInteger(box: OptionalIntIdBox)(): Set[CtValidation] = {
     box.value match {
       case Some(x) if x < 0 => Set(CtValidation(Some(box.id), s"error.${box.id}.mustBeZeroOrPositive"))

--- a/src/main/scala/uk/gov/hmrc/ct/computations/CP33.scala
+++ b/src/main/scala/uk/gov/hmrc/ct/computations/CP33.scala
@@ -22,7 +22,7 @@ import uk.gov.hmrc.ct.computations.retriever.ComputationsBoxRetriever
 case class CP33(value: Option[Int]) extends CtBoxIdentifier(name = "Profit/Losses on disposal of assets") with CtOptionalInteger with Input
   with ValidatableBox[ComputationsBoxRetriever] {
   override def validate(boxRetriever: ComputationsBoxRetriever): Set[CtValidation] = {
-    validateZeroOrPositiveInteger(this)
+    isPositiveOrNegative(this)
   }
 }
 

--- a/src/test/scala/uk/gov/hmrc/ct/BoxValidationFixture.scala
+++ b/src/test/scala/uk/gov/hmrc/ct/BoxValidationFixture.scala
@@ -28,6 +28,21 @@ trait BoxValidationFixture[T <: ComputationsBoxRetriever] extends WordSpec with 
   //This can be overridden if mock box retriever calls need to be made
   def setUpMocks(): Unit = Unit
 
+  def testIsPositiveOrNegative(boxId: String, builder: Option[Int] => ValidatableBox[T]) = {
+
+    setUpMocks()
+
+    "fail must be zero or positive validation when negative" in {
+      builder(Some(-55)).validate(boxRetriever).contains(CtValidation(Some(boxId), s"error.$boxId.mustBeZeroOrPositive")) shouldBe false
+    }
+    "pass must be zero or positive validation when zero" in {
+      builder(Some(0)).validate(boxRetriever).contains(CtValidation(Some(boxId), s"error.$boxId.mustBeZeroOrPositive")) shouldBe false
+    }
+    "pass must be zero or positive validation when positive" in {
+      builder(Some(55)).validate(boxRetriever).contains(CtValidation(Some(boxId), s"error.$boxId.mustBeZeroOrPositive")) shouldBe false
+    }
+  }
+
   def testBoxIsZeroOrPositive(boxId: String, builder: Option[Int] => ValidatableBox[T]) = {
 
     setUpMocks()

--- a/src/test/scala/uk/gov/hmrc/ct/computations/CP33Spec.scala
+++ b/src/test/scala/uk/gov/hmrc/ct/computations/CP33Spec.scala
@@ -25,6 +25,6 @@ class CP33Spec extends WordSpec with MockitoSugar with Matchers with BoxValidati
 
   val boxRetriever = mock[ComputationsBoxRetriever]
 
-  testBoxIsZeroOrPositive("CP33", CP33.apply)
+  testIsPositiveOrNegative("CP33", CP33.apply)
 
 }


### PR DESCRIPTION
CATO-4894  Modified CP33 to allow positive and negative numbers including a new method & trait that supports this logic 

Large file changes due to year change