### PR TITLE
DLS-7084 | Fix writeoff error message args to handle loan amount correctly

### DIFF
--- a/src/main/scala/uk/gov/hmrc/ct/ct600a/v3/LoansToParticipators.scala
+++ b/src/main/scala/uk/gov/hmrc/ct/ct600a/v3/LoansToParticipators.scala
@@ -298,9 +298,9 @@ case class WriteOff(id: String, amount: Option[Int], amountBetween06042022To0604
 
     validateWriteOff(invalidDate(boxRetriever), s"$writeOffErrorCode.$writeOffIndex.date.range", errorArgsWriteOffDate(boxRetriever), loanIndex) ++
     validateWriteOff(invalidWriteOffAmount, s"$writeOffErrorCode.$writeOffIndex.amount.value", None, loanIndex) ++
-    validateWriteOff(invalidWriteOffBeforeApril2016Amount, s"$writeOffErrorCode.$writeOffIndex.beforeApril2016Amount.value", Some(Seq(amount.toString)), loanIndex) ++
-    validateWriteOff(invalidWriteOffBeforeApril2022Amount, s"$writeOffErrorCode.$writeOffIndex.beforeApril2022Amount.value", Some(Seq(amount.toString)), loanIndex) ++
-    validateWriteOff(invalidWriteOffBeforeApril2023Amount, s"$writeOffErrorCode.$writeOffIndex.beforeApril2023Amount.value", Some(Seq(amount.toString)), loanIndex) ++
+    validateWriteOff(invalidWriteOffBeforeApril2016Amount, s"$writeOffErrorCode.$writeOffIndex.beforeApril2016Amount.value", Some(Seq(amount.getOrElse(0).toString)), loanIndex) ++
+    validateWriteOff(invalidWriteOffBeforeApril2022Amount, s"$writeOffErrorCode.$writeOffIndex.beforeApril2022Amount.value", Some(Seq(amount.getOrElse(0).toString)), loanIndex) ++
+    validateWriteOff(invalidWriteOffBeforeApril2023Amount, s"$writeOffErrorCode.$writeOffIndex.beforeApril2023Amount.value", Some(Seq(amount.getOrElse(0).toString)), loanIndex) ++
     validateWriteOff(invalidApEndDateRequired(boxRetriever), s"$writeOffErrorCode.$writeOffIndex.endDateOfAP.required", None, loanIndex) ++
     validateWriteOff(invalidApEndDateRange(boxRetriever), s"$writeOffErrorCode.$writeOffIndex.endDateOfAP.range", errorArgsWriteOffApEndDate(boxRetriever), loanIndex)
   }

--- a/src/test/scala/uk/gov/hmrc/ct/ct600/v3/LoansToParticipatorsSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/ct/ct600/v3/LoansToParticipatorsSpec.scala
@@ -475,6 +475,7 @@ class LoansToParticipatorsSpec extends WordSpec with Matchers {
       errors.size shouldBe 1
       errors.head.boxId shouldBe Some("LoansToParticipators")
       errors.head.errorMessageKey shouldBe "error.compoundList.loans.0.writeOffs.0.beforeApril2016Amount.value"
+      errors.head.args shouldBe Some(List("50"))
     }
 
     "return an error if a write off has a date > 9 months after current AP End Date and no apEndDate" in {


### PR DESCRIPTION
Fix to handle error messages for writeoffs where the validation wasn't handling optional amount correctly as a result was displaying incorrectly as below

<img width="475" alt="Screenshot 2023-04-05 at 12 24 50" src="https://user-images.githubusercontent.com/102029646/230066959-d4cf8b29-7942-430b-a7a2-6bd7a1192b7c.png">

Below is updated fix and displays the amount in error msg correct 
<img width="587" alt="Screenshot 2023-04-05 at 12 40 37" src="https://user-images.githubusercontent.com/102029646/230070091-9b7abf90-c1de-437b-8b9b-a2aed37d4662.png">

